### PR TITLE
logging: fix caller resolution, effective-level lookup and validation

### DIFF
--- a/src/main/java/de/cuioss/tools/ToolsLogMessages.java
+++ b/src/main/java/de/cuioss/tools/ToolsLogMessages.java
@@ -28,7 +28,6 @@ import lombok.experimental.UtilityClass;
  *   <li>001-099: INFO level</li>
  *   <li>100-199: WARN level</li>
  *   <li>200-299: ERROR level</li>
- *   <li>300-399: FATAL level</li>
  * </ul>
  *
  * <h2>Usage Examples</h2>

--- a/src/main/java/de/cuioss/tools/logging/CuiLogger.java
+++ b/src/main/java/de/cuioss/tools/logging/CuiLogger.java
@@ -16,6 +16,7 @@
 package de.cuioss.tools.logging;
 
 import java.util.function.Supplier;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
@@ -715,11 +716,23 @@ public class CuiLogger {
     }
 
     /**
-     * @return CUI log level derived from JUL log level. E.g. FINEST(300) matches
-     * TRACE(400), CONFIG(700) matches DEBUG(500), ALL matches TRACE.
+     * @return CUI log level derived from the effective JUL log level. E.g. FINEST(300) matches
+     * TRACE(400), CONFIG(700) matches DEBUG(500), ALL matches TRACE. Since
+     * {@link Logger#getLevel()} returns {@code null} for loggers inheriting their level (the
+     * common case), the effective level is resolved by walking up {@link Logger#getParent()}
+     * until a configured level is found, falling back to {@link Level#INFO} if none is
+     * configured at all.
      */
     public LogLevel getLogLevel() {
-        return LogLevel.from(delegate.getLevel());
+        var current = delegate;
+        while (null != current) {
+            final var level = current.getLevel();
+            if (null != level) {
+                return LogLevel.from(level);
+            }
+            current = current.getParent();
+        }
+        return LogLevel.from(Level.INFO);
     }
 
 }

--- a/src/main/java/de/cuioss/tools/logging/CuiLoggerFactory.java
+++ b/src/main/java/de/cuioss/tools/logging/CuiLoggerFactory.java
@@ -79,7 +79,9 @@ public class CuiLoggerFactory {
 
         final StackTraceElement[] stackTraceElements = Thread.currentThread().getStackTrace();
 
-        if (null == stackTraceElements || stackTraceElements.length < 5) {
+        // The minimal valid stack consists of four frames: Thread#getStackTrace,
+        // findCallerInternal, the marker method (e.g. getLogger) and the actual caller.
+        if (null == stackTraceElements || stackTraceElements.length < 4) {
             return Optional.empty();
         }
 

--- a/src/main/java/de/cuioss/tools/logging/LogLevel.java
+++ b/src/main/java/de/cuioss/tools/logging/LogLevel.java
@@ -24,6 +24,7 @@ import org.jspecify.annotations.Nullable;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -101,14 +102,15 @@ public enum LogLevel {
     }
 
     /**
-     * @param juliLevel the Java Util Logging level to convert
+     * @param juliLevel the Java Util Logging level to convert, must not be null
      * @return CUI log level
+     * @throws NullPointerException if juliLevel is null
      */
     public static LogLevel from(final Level juliLevel) {
+        Objects.requireNonNull(juliLevel, "juliLevel must not be null");
         // highest value first, i.e. OFF, ERROR, WARN, INFO, DEBUG, TRACE
         List<LogLevel> sortedCuiLevels = CollectionLiterals.mutableList(values());
-        sortedCuiLevels.sort(Comparator.comparing(logLevel -> logLevel.getJuliLevel().intValue()));
-        sortedCuiLevels.sort(Comparator.reverseOrder());
+        sortedCuiLevels.sort(Comparator.comparingInt((LogLevel logLevel) -> logLevel.getJuliLevel().intValue()).reversed());
 
         final var juliIntLevel = juliLevel.intValue();
         for (LogLevel cuiLevel : sortedCuiLevels) {
@@ -121,8 +123,10 @@ public enum LogLevel {
     }
 
     private void doLog(final Logger logger, final String message, final @Nullable Throwable throwable) {
-        // We go up the stack-trace until we found the call from CuiLogger.
-        final var caller = MoreReflection.findCallerElement(throwable, MARKER_CLASS_NAMES);
+        // We go up the current call-stack until we found the call from CuiLogger. The throwable
+        // must not be used here: its stack-trace describes where it was created, not where the
+        // log-statement was issued.
+        final var caller = MoreReflection.findCallerElement(null, MARKER_CLASS_NAMES);
         if (caller.isPresent()) {
             // This is needed because otherwise LogRecord will assume this class and this
             // method as

--- a/src/main/java/de/cuioss/tools/logging/LogRecordModel.java
+++ b/src/main/java/de/cuioss/tools/logging/LogRecordModel.java
@@ -17,6 +17,7 @@ package de.cuioss.tools.logging;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import java.util.function.Supplier;
@@ -146,12 +147,15 @@ public class LogRecordModel implements LogRecord {
     private static final String AFTER_PREFIX = ": ";
 
     @Getter
+    @NonNull
     private final String prefix;
 
     @Getter
+    @NonNull
     private final Integer identifier;
 
     @Getter
+    @NonNull
     private final String template;
 
     /**
@@ -189,7 +193,7 @@ public class LogRecordModel implements LogRecord {
     }
 
     @Builder
-    private LogRecordModel(String prefix, Integer identifier, String template) {
+    private LogRecordModel(@NonNull String prefix, @NonNull Integer identifier, @NonNull String template) {
         this.prefix = prefix;
         this.identifier = identifier;
         this.template = template;

--- a/src/test/java/de/cuioss/tools/logging/CuiLoggerFactoryTest.java
+++ b/src/test/java/de/cuioss/tools/logging/CuiLoggerFactoryTest.java
@@ -93,6 +93,25 @@ class CuiLoggerFactoryTest {
     }
 
     @Test
+    void shouldAutoDetectCallerFromBottomOfStackFrame() throws InterruptedException {
+        // A Thread subclass overriding run() and calling getLogger() directly produces the
+        // minimal possible stack of four frames: Thread#getStackTrace, findCallerInternal,
+        // getLogger and run() itself. Caller detection must still succeed for such a stack.
+        final CuiLogger[] loggerHolder = new CuiLogger[1];
+        Thread thread = new Thread() {
+            @Override
+            public void run() {
+                loggerHolder[0] = CuiLoggerFactory.getLogger();
+            }
+        };
+        thread.start();
+        thread.join();
+
+        assertNotNull(loggerHolder[0]);
+        assertTrue(loggerHolder[0].getName().startsWith(CuiLoggerFactoryTest.class.getName()));
+    }
+
+    @Test
     void shouldHandleMultithreadedInitialization() throws InterruptedException {
         // Test concurrent initialization to ensure thread safety
         final int threadCount = 10;

--- a/src/test/java/de/cuioss/tools/logging/CuiLoggerTest.java
+++ b/src/test/java/de/cuioss/tools/logging/CuiLoggerTest.java
@@ -120,7 +120,8 @@ class CuiLoggerTest {
             assertNull(logger.getWrapped().getLevel());
 
             var logLevel = assertDoesNotThrow(logger::getLogLevel);
-            assertNotNull(logLevel);
+            assertEquals(LogLevel.INFO, logLevel,
+                    "Should resolve INFO from the root logger (or the documented fallback)");
         }
     }
 

--- a/src/test/java/de/cuioss/tools/logging/CuiLoggerTest.java
+++ b/src/test/java/de/cuioss/tools/logging/CuiLoggerTest.java
@@ -111,6 +111,17 @@ class CuiLoggerTest {
             underTest.getWrapped().setLevel(Level.INFO);
             assertEquals(LogLevel.INFO, underTest.getLogLevel());
         }
+
+        @Test
+        @DisplayName("Should resolve effective log level for logger with inherited level")
+        void shouldResolveEffectiveLogLevelForInheritedLevel() {
+            var logger = new CuiLogger("de.cuioss.tools.logging.inherited.level.LevelInheritingLogger");
+            // Fresh loggers inherit their level, i.e. Logger.getLevel() returns null
+            assertNull(logger.getWrapped().getLevel());
+
+            var logLevel = assertDoesNotThrow(logger::getLogLevel);
+            assertNotNull(logLevel);
+        }
     }
 
     @Nested
@@ -549,6 +560,33 @@ class CuiLoggerTest {
             assumeTrue(underTest.isErrorEnabled(), "Error logging must be enabled");
             underTest.error(throwable, message);
             handler.assertMessagePresent(message, Level.SEVERE, throwable);
+        }
+    }
+
+    @Nested
+    @DisplayName("Caller Resolution Tests")
+    class CallerResolutionTests {
+
+        @Test
+        @DisplayName("Should resolve source class and method for plain log call")
+        void shouldResolveCallerForPlainLogCall() {
+            underTest.info("plain message");
+
+            var logRecord = handler.records.getFirst();
+            assertEquals(CallerResolutionTests.class.getName(), logRecord.getSourceClassName());
+            assertEquals("shouldResolveCallerForPlainLogCall", logRecord.getSourceMethodName());
+        }
+
+        @Test
+        @DisplayName("Should resolve source class and method for log call with throwable")
+        void shouldResolveCallerForLogCallWithThrowable() {
+            // The throwable is created in a different method (before()). The caller must
+            // nevertheless be resolved from the current stack, not the throwable's stack.
+            underTest.error(throwable, "message with throwable");
+
+            var logRecord = handler.records.getFirst();
+            assertEquals(CallerResolutionTests.class.getName(), logRecord.getSourceClassName());
+            assertEquals("shouldResolveCallerForLogCallWithThrowable", logRecord.getSourceMethodName());
         }
     }
 

--- a/src/test/java/de/cuioss/tools/logging/LogLevelTest.java
+++ b/src/test/java/de/cuioss/tools/logging/LogLevelTest.java
@@ -57,6 +57,12 @@ class LogLevelTest {
     }
 
     @Test
+    void shouldRejectNullJulLevel() {
+        assertThrows(NullPointerException.class, () -> LogLevel.from(null),
+                "LogLevel.from must reject null levels");
+    }
+
+    @Test
     void shouldHandleLogLevelEnabled() {
         // Given
         logger.setLevel(Level.ALL);

--- a/src/test/java/de/cuioss/tools/logging/LogRecordModelTest.java
+++ b/src/test/java/de/cuioss/tools/logging/LogRecordModelTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Test class for {@link LogRecordModel} ensuring proper log message formatting
@@ -91,6 +92,30 @@ class LogRecordModelTest {
         var result = infoModel.format(null, null);
         assertEquals(PREFIX + ": null-null", result);
         LOGGER.info(infoModel.format(null, null));
+    }
+
+    @Test
+    void shouldProvideSupplierForLazyFormatting() {
+        var supplier = infoModel.supplier("A", 2);
+        assertEquals(PREFIX + ": A-2", supplier.get());
+
+        var errorSupplier = errorModel.supplier("Connection timeout");
+        assertEquals("ERROR-500: Operation failed: Connection timeout", errorSupplier.get());
+    }
+
+    @Test
+    void shouldValidateBuilderParametersForNull() {
+        var emptyBuilder = LogRecordModel.builder();
+        assertThrows(NullPointerException.class, emptyBuilder::build);
+
+        var builderWithoutPrefix = LogRecordModel.builder().identifier(1).template("template");
+        assertThrows(NullPointerException.class, builderWithoutPrefix::build);
+
+        var builderWithoutIdentifier = LogRecordModel.builder().prefix("PREFIX").template("template");
+        assertThrows(NullPointerException.class, builderWithoutIdentifier::build);
+
+        var builderWithoutTemplate = LogRecordModel.builder().prefix("PREFIX").identifier(1);
+        assertThrows(NullPointerException.class, builderWithoutTemplate::build);
     }
 
     @Test

--- a/src/test/java/de/cuioss/tools/logging/TestLogHandler.java
+++ b/src/test/java/de/cuioss/tools/logging/TestLogHandler.java
@@ -28,8 +28,6 @@ public class TestLogHandler extends Handler {
 
     List<LogRecord> records = new ArrayList<>();
 
-    Level lastLevel = Level.FINEST;
-
     @Override
     public void publish(LogRecord logRecord) {
         records.add(logRecord);


### PR DESCRIPTION
## Summary

Cluster B of the project-analysis fix series (findings catalog: `doc/analysis-findings.md` on main, IDs LOG-1..LOG-10).

- **LOG-1 (high)**: `LogLevel.doLog` passed the user-supplied `Throwable` into `MoreReflection.findCallerElement`, which scans the *exception's* stack trace (where it was constructed) instead of the current call stack — so every log call with a throwable reported `de.cuioss.tools.logging.LogLevel#doLog` as source instead of the real caller. Now always resolves from the current stack.
- **LOG-2 (high)**: `CuiLogger.getLogLevel()` threw `NullPointerException` for any logger inheriting its level (the default configuration), because `Logger.getLevel()` returns null then. Now resolves the effective level by walking `getParent()`, falling back to `Level.INFO`; `LogLevel.from` validates and documents its null contract.
- **LOG-3**: `CuiLoggerFactory.findCallerInternal` rejected valid 4-frame stacks (`< 5` off-by-one), so `getLogger()` failed when called from a bottom-of-stack method (e.g. `main`, `Thread.run`). Guard fixed to `< 4`.
- **LOG-4**: `LogRecordModel` javadoc claims "All builder parameters are validated for null" — now they actually are (`@NonNull` on prefix/identifier/template).
- **LOG-5**: removed the dead double-sort in `LogLevel.from` (first sort was immediately discarded); replaced with a single explicit descending sort.
- **LOG-6**: removed the "300-399: FATAL level" range from `ToolsLogMessages` javadoc — no FATAL level exists in this framework.
- **LOG-7..LOG-10 (tests/cleanup)**: new tests pin source class/method resolution with and without throwable (fails without LOG-1 fix), inherited-level `getLogLevel()`, bottom-of-stack `getLogger()` (via a `Thread` subclass, fails without LOG-3 fix), and `LogRecord.supplier(...)`; removed dead `TestLogHandler.lastLevel` field.

## Test plan

- `./mvnw clean install` — BUILD SUCCESS, 802 tests, 0 failures/errors/skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKzn4Upj33uRFvWQep3UzE

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKzn4Upj33uRFvWQep3UzE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved effective log level detection for loggers with inherited (unset) JUL levels.
  * Enhanced caller resolution in log records, including minimal-stack and throwable-related scenarios.
* **Documentation**
  * Updated the published “Message Identifier Ranges” list to stop at the ERROR level.
* **Tests**
  * Added/expanded tests for inherited log levels, caller auto-detection, lazy formatting, and null/required-field validation (including builder failures).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->