### PR TITLE
collect: fix equality contracts, immutability leaks and doc drift

### DIFF
--- a/src/main/java/de/cuioss/tools/collect/CollectionBuilder.java
+++ b/src/main/java/de/cuioss/tools/collect/CollectionBuilder.java
@@ -223,7 +223,7 @@ public final class CollectionBuilder<E> implements Iterable<E> {
      * </p>
      *
      * @param o a {@link java.lang.Object} object
-     * @return see {@link java.util.Collection#isEmpty()}
+     * @return see {@link java.util.Collection#contains(Object)}
      */
     public boolean contains(Object o) {
         return collector.contains(o);
@@ -416,7 +416,7 @@ public final class CollectionBuilder<E> implements Iterable<E> {
      *
      * @return an immutable {@link java.util.Set} representation of the builders
      *         content, the actual implementation calls
-     *         {@link java.util.Collections#unmodifiableList(List)}. The underlying
+     *         {@link java.util.Collections#unmodifiableSet(Set)}. The underlying
      *         {@link java.util.Collection} will be copied by calling
      *         {@link #toMutableSet()}
      */
@@ -503,7 +503,7 @@ public final class CollectionBuilder<E> implements Iterable<E> {
      * @return an array representation of the builders content
      */
     @SuppressWarnings("unchecked")
-    public E[] toArray(Class<? super E> targetType) {
+    public E[] toArray(Class<E> targetType) {
         if (isEmpty()) {
             return (E[]) Array.newInstance(targetType, 0);
         }
@@ -598,7 +598,8 @@ public final class CollectionBuilder<E> implements Iterable<E> {
      * will be used as it is, there will be no filtering as defined within
      * {@link #addNullValues(boolean)}
      *
-     * @param source may be null
+     * @param source may be null. If it is {@code null} the resulting builder will
+     *               be empty
      * @return the newly created {@link de.cuioss.tools.collect.CollectionBuilder}
      * @param <E> a E class
      */

--- a/src/main/java/de/cuioss/tools/collect/CollectionLiterals.java
+++ b/src/main/java/de/cuioss/tools/collect/CollectionLiterals.java
@@ -120,12 +120,15 @@ public class CollectionLiterals {
     /**
      * Creates a <i>mutable</i> {@code List} instance containing the given element
      *
-     * @param element to be added
+     * @param element to be added. If it is {@code null} it will not be added
      * @return the <i>mutable</i> {@link java.util.List} with the given element
      * @param <E> a E class
      */
     public static <E> List<E> mutableList(E element) {
         List<E> list = new ArrayList<>();
+        if (null == element) {
+            return list;
+        }
         list.add(element);
         return list;
     }
@@ -133,7 +136,7 @@ public class CollectionLiterals {
     /**
      * Creates a <i>mutable</i> {@code List} instance containing the given elements.
      *
-     * @param elements to be added. If it is null and empty <i>mutable</i> list will
+     * @param elements to be added. If it is null, an empty <i>mutable</i> list will
      *                 be returned
      * @return the <i>mutable</i> {@link java.util.List} with the given elements
      * @param <E> a E class
@@ -150,7 +153,7 @@ public class CollectionLiterals {
     /**
      * Creates a <i>mutable</i> {@code List} instance containing the given elements.
      *
-     * @param elements to be added. If it is null and empty <i>mutable</i> list will
+     * @param elements to be added. If it is null, an empty <i>mutable</i> list will
      *                 be returned
      * @return the <i>mutable</i> {@link java.util.List} with the given elements
      * @param <E> a E class
@@ -183,7 +186,7 @@ public class CollectionLiterals {
     /**
      * Creates a <i>mutable</i> {@code List} instance containing the given elements.
      *
-     * @param elements to be added. If it is null and empty <i>mutable</i> list will
+     * @param elements to be added. If it is null, an empty <i>mutable</i> list will
      *                 be returned
      * @return the <i>mutable</i> {@link java.util.List} with the given elements
      * @param <E> a E class
@@ -214,7 +217,8 @@ public class CollectionLiterals {
      * Creates an <i>immutable</i> {@code List} instance containing the given
      * elements.
      *
-     * @param elements to be wrapped, must not be null
+     * @param elements to be wrapped. If it is {@code null} an empty
+     *                 <i>immutable</i> instance will be returned
      * @return the <i>immutable</i> {@link java.util.List} with the given elements
      * @param <E> a E class
      */
@@ -230,7 +234,8 @@ public class CollectionLiterals {
      * Creates an <i>immutable</i> {@code List} instance containing the given
      * element.
      *
-     * @param element to be wrapped, must not be null
+     * @param element to be wrapped. If it is {@code null} an empty
+     *                <i>immutable</i> instance will be returned
      * @return the <i>immutable</i> {@link java.util.List} with the given elements
      * @param <E> a E class
      */
@@ -245,7 +250,8 @@ public class CollectionLiterals {
      * Creates an <i>immutable</i> {@code List} instance containing the given
      * elements.
      *
-     * @param elements to be wrapped, must not be null
+     * @param elements to be wrapped. If it is {@code null} an empty
+     *                 <i>immutable</i> instance will be returned
      * @return the <i>immutable</i> {@link java.util.List} with the given elements
      * @param <E> a E class
      */
@@ -260,7 +266,8 @@ public class CollectionLiterals {
      * Creates an <i>immutable</i> {@code List} instance containing the given
      * elements.
      *
-     * @param elements to be wrapped, must not be null
+     * @param elements to be wrapped. If it is {@code null} an empty
+     *                 <i>immutable</i> instance will be returned
      * @return the <i>immutable</i> {@link java.util.List} with the given elements.
      *         It implicitly creates a copy
      * @param <E> a E class
@@ -277,7 +284,8 @@ public class CollectionLiterals {
      * Creates an <i>immutable</i> {@code List} instance containing the given
      * elements. <em>Caution:</em> The stream will be consumed by this operation
      *
-     * @param elements to be wrapped, must not be null
+     * @param elements to be wrapped. If it is {@code null} an empty
+     *                 <i>immutable</i> instance will be returned
      * @return the <i>immutable</i> {@link java.util.List} with the given elements
      * @param <E> a E class
      */
@@ -292,7 +300,8 @@ public class CollectionLiterals {
      * Creates an <i>immutable</i> {@code List} instance containing the given
      * elements.
      *
-     * @param elements to be wrapped, must not be null
+     * @param elements to be wrapped. If it is {@code null} an empty
+     *                 <i>immutable</i> instance will be returned
      * @return the <i>immutable</i> {@link java.util.List} with the given elements
      * @param <E> a E class
      */
@@ -349,7 +358,7 @@ public class CollectionLiterals {
     /**
      * Creates a <i>mutable</i> {@code Set} instance containing the given elements.
      *
-     * @param elements to be added. If it is null and empty <i>mutable</i> list will
+     * @param elements to be added. If it is null, an empty <i>mutable</i> list will
      *                 be returned
      * @return the <i>mutable</i> {@link java.util.Set} with the given elements
      * @param <E> a E class
@@ -367,7 +376,7 @@ public class CollectionLiterals {
     /**
      * Creates a <i>mutable</i> {@code Set} instance containing the given elements.
      *
-     * @param elements to be added. If it is null and empty <i>mutable</i> list will
+     * @param elements to be added. If it is null, an empty <i>mutable</i> list will
      *                 be returned
      * @return the <i>mutable</i> {@link java.util.Set} with the given elements
      * @param <E> a E class
@@ -382,7 +391,7 @@ public class CollectionLiterals {
     /**
      * Creates a <i>mutable</i> {@code Set} instance containing the given elements.
      *
-     * @param elements to be added. If it is null and empty <i>mutable</i> list will
+     * @param elements to be added. If it is null, an empty <i>mutable</i> list will
      *                 be returned
      * @return the <i>mutable</i> {@link java.util.Set} with the given elements
      * @param <E> a E class
@@ -402,7 +411,7 @@ public class CollectionLiterals {
      * Creates a <i>mutable</i> {@code Set} instance containing the given elements.
      * <em>Caution:</em> The stream will be consumed by this operation
      *
-     * @param elements to be added. If it is null and empty <i>mutable</i>
+     * @param elements to be added. If it is null, an empty <i>mutable</i>
      *                 {@link java.util.Set} will be returned
      * @return the <i>mutable</i> {@link java.util.Set} with the given elements
      * @param <E> a E class
@@ -419,7 +428,7 @@ public class CollectionLiterals {
     /**
      * Creates an empty immutable set.
      *
-     * @return a newly created empty {@link java.util.HashSet} Convenience method
+     * @return an empty <i>immutable</i> {@link java.util.Set}. Convenience method
      *         for {@link java.util.Collections#emptySet()}
      * @param <E> a E class
      */
@@ -431,7 +440,8 @@ public class CollectionLiterals {
      * Creates an <i>immutable</i> {@code Set} instance containing the given
      * elements.
      *
-     * @param element to be wrapped, must not be null
+     * @param element to be wrapped. If it is {@code null} an empty
+     *                <i>immutable</i> instance will be returned
      * @return the <i>immutable</i> {@link java.util.Set} with the given elements
      * @param <E> a E class
      */
@@ -446,7 +456,8 @@ public class CollectionLiterals {
      * Creates an <i>immutable</i> {@code Set} instance containing the given
      * elements.
      *
-     * @param elements to be wrapped, must not be null
+     * @param elements to be wrapped. If it is {@code null} an empty
+     *                 <i>immutable</i> instance will be returned
      * @return the <i>immutable</i> {@link java.util.Set} with the given elements
      * @param <E> a E class
      */
@@ -477,7 +488,8 @@ public class CollectionLiterals {
      * Creates an <i>immutable</i> {@code Set} instance containing the given
      * elements.
      *
-     * @param elements to be wrapped, must not be null
+     * @param elements to be wrapped. If it is {@code null} an empty
+     *                 <i>immutable</i> instance will be returned
      * @return the <i>immutable</i> {@link java.util.Set} with the given elements
      * @param <E> a E class
      */
@@ -492,7 +504,8 @@ public class CollectionLiterals {
      * Creates an <i>immutable</i> {@code Set} instance containing the given
      * elements. <em>Caution:</em> The stream will be consumed by this operation
      *
-     * @param elements to be wrapped, must not be null
+     * @param elements to be wrapped. If it is {@code null} an empty
+     *                 <i>immutable</i> instance will be returned
      * @return the <i>immutable</i> {@link java.util.Set} with the given elements
      * @param <E> a E class
      */
@@ -553,7 +566,7 @@ public class CollectionLiterals {
      * Creates a <i>mutable</i> {@code SortedSet} instance containing the given
      * elements.
      *
-     * @param elements to be added. If it is null and empty <i>mutable</i> list will
+     * @param elements to be added. If it is null, an empty <i>mutable</i> list will
      *                 be returned
      * @return the <i>mutable</i> {@link java.util.TreeSet} with the given elements
      * @param <E> a E class
@@ -571,7 +584,7 @@ public class CollectionLiterals {
      * Creates a <i>mutable</i> {@code SortedSet} instance containing the given
      * elements.
      *
-     * @param elements to be added. If it is null and empty <i>mutable</i> list will
+     * @param elements to be added. If it is null, an empty <i>mutable</i> list will
      *                 be returned
      * @return the <i>mutable</i> {@link java.util.Set} with the given elements
      * @param <E> a E class
@@ -591,7 +604,7 @@ public class CollectionLiterals {
      * Creates a <i>mutable</i> {@code SortedSet} instance containing the given
      * elements. <em>Caution:</em> The stream will be consumed by this operation
      *
-     * @param elements to be added. If it is null and empty <i>mutable</i> list will
+     * @param elements to be added. If it is null, an empty <i>mutable</i> list will
      *                 be returned
      * @return the <i>mutable</i> {@link java.util.Set} with the given elements
      * @param <E> a E class
@@ -620,7 +633,8 @@ public class CollectionLiterals {
      * Creates an <i>immutable</i> {@code SortedSet} instance containing the given
      * elements.
      *
-     * @param element to be wrapped, must not be null
+     * @param element to be wrapped. If it is {@code null} an empty
+     *                <i>immutable</i> instance will be returned
      * @return the <i>immutable</i> {@link java.util.Set} with the given elements
      * @param <E> a E class
      */
@@ -635,7 +649,8 @@ public class CollectionLiterals {
      * Creates an <i>immutable</i> {@code SortedSet} instance containing the given
      * elements.
      *
-     * @param elements to be wrapped, must not be null
+     * @param elements to be wrapped. If it is {@code null} an empty
+     *                 <i>immutable</i> instance will be returned
      * @return the <i>immutable</i> {@link java.util.Set} with the given elements
      * @param <E> a E class
      */
@@ -648,7 +663,8 @@ public class CollectionLiterals {
      * Creates an <i>immutable</i> {@code SortedSet} instance containing the given
      * elements.
      *
-     * @param elements to be wrapped, must not be null
+     * @param elements to be wrapped. If it is {@code null} an empty
+     *                 <i>immutable</i> instance will be returned
      * @return the <i>immutable</i> {@link java.util.Set} with the given elements
      * @param <E> a E class
      */
@@ -660,7 +676,8 @@ public class CollectionLiterals {
      * Creates an <i>immutable</i> {@code SortedSet} instance containing the given
      * elements.
      *
-     * @param elements to be wrapped, must not be null
+     * @param elements to be wrapped. If it is {@code null} an empty
+     *                 <i>immutable</i> instance will be returned
      * @return the <i>immutable</i> {@link java.util.Set} with the given elements
      * @param <E> a E class
      */
@@ -672,7 +689,8 @@ public class CollectionLiterals {
      * Creates an <i>immutable</i> {@code SortedSet} instance containing the given
      * elements. <em>Caution:</em> The stream will be consumed by this operation
      *
-     * @param elements to be wrapped, must not be null
+     * @param elements to be wrapped. If it is {@code null} an empty
+     *                 <i>immutable</i> instance will be returned
      * @return the <i>immutable</i> {@link java.util.Set} with the given elements
      * @param <E> a E class
      */
@@ -774,7 +792,8 @@ public class CollectionLiterals {
     /**
      * Creates an empty immutable map.
      *
-     * @return an empty <i>mutable</i> Map
+     * @return an empty <i>immutable</i> Map. Convenience method for
+     *         {@link java.util.Collections#emptyMap()}
      * @param <K> a K class
      * @param <V> a V class
      */
@@ -783,15 +802,22 @@ public class CollectionLiterals {
     }
 
     /**
-     * Shorthand to {@link java.util.Collections#unmodifiableMap(Map)}
+     * Creates an <i>immutable</i> {@code Map} instance containing the entries of
+     * the given map. The entries are copied into a new map which is then wrapped
+     * using {@link java.util.Collections#unmodifiableMap(Map)}, so later
+     * modifications of the given source do not affect the returned map.
      *
-     * @param source a {@link java.util.Map} object
+     * @param source a {@link java.util.Map} object. If it is {@code null} an
+     *               empty <i>immutable</i> Map will be returned
      * @return an <i>immutable</i> Map with the given elements
      * @param <K> a K class
      * @param <V> a V class
      */
     public static <K, V> Map<K, V> immutableMap(Map<K, V> source) {
-        return Collections.unmodifiableMap(source);
+        if (null == source) {
+            return Collections.emptyMap();
+        }
+        return Collections.unmodifiableMap(new HashMap<>(source));
     }
 
     /**

--- a/src/main/java/de/cuioss/tools/collect/CollectionLiterals.java
+++ b/src/main/java/de/cuioss/tools/collect/CollectionLiterals.java
@@ -24,10 +24,14 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.SortedSet;
+import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Stream;
 
@@ -817,7 +821,21 @@ public class CollectionLiterals {
         if (null == source) {
             return Collections.emptyMap();
         }
-        return Collections.unmodifiableMap(new HashMap<>(source));
+        return copyToUnmodifiableMap(source);
+    }
+
+    /**
+     * Copies the given map into an unmodifiable view, preserving sorting for
+     * {@link SortedMap} sources and iteration order for all others.
+     */
+    static <K, V> Map<K, V> copyToUnmodifiableMap(Map<K, V> source) {
+        if (source instanceof NavigableMap<K, V> navigableMap) {
+            return Collections.unmodifiableNavigableMap(new TreeMap<>(navigableMap));
+        }
+        if (source instanceof SortedMap<K, V> sortedMap) {
+            return Collections.unmodifiableSortedMap(new TreeMap<>(sortedMap));
+        }
+        return Collections.unmodifiableMap(new LinkedHashMap<>(source));
     }
 
     /**

--- a/src/main/java/de/cuioss/tools/collect/MapBuilder.java
+++ b/src/main/java/de/cuioss/tools/collect/MapBuilder.java
@@ -18,7 +18,6 @@ package de.cuioss.tools.collect;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -241,7 +240,7 @@ public final class MapBuilder<K, V> {
      *         map
      */
     public Map<K, V> toImmutableMap() {
-        return Collections.unmodifiableMap(new HashMap<>(collector));
+        return CollectionLiterals.copyToUnmodifiableMap(collector);
     }
 
     /**

--- a/src/main/java/de/cuioss/tools/collect/MapBuilder.java
+++ b/src/main/java/de/cuioss/tools/collect/MapBuilder.java
@@ -144,8 +144,8 @@ public final class MapBuilder<K, V> {
      * put.
      * </p>
      *
-     * @param key   to be put as key, must not be empty
-     * @param value to be put as value, must not be empty
+     * @param key   to be put as key
+     * @param value to be put as value, may be {@code null}
      * @return the instance itself in order to use it in a fluent way.
      */
     public MapBuilder<K, V> put(K key, V value) {
@@ -156,8 +156,8 @@ public final class MapBuilder<K, V> {
     /**
      * Puts the entry into the map, if the value is not {@code null}.
      *
-     * @param key   to be put as key, must not be empty
-     * @param value to be put as value
+     * @param key   to be put as key
+     * @param value to be put as value, if it is {@code null} it will be ignored
      * @return the instance itself in order to use it in a fluent way.
      */
     public MapBuilder<K, V> putIfNotNull(K key, V value) {
@@ -234,12 +234,14 @@ public final class MapBuilder<K, V> {
      * </p>
      *
      * @return an immutable {@link java.util.Map} representation of the builders
-     *         content, the actual implementation does not create a copy but
-     *         provides an unmodifiable view using
-     *         {@link java.util.Collections#unmodifiableMap(Map)}
+     *         content, the actual implementation creates a copy of the builders
+     *         content and wraps it using
+     *         {@link java.util.Collections#unmodifiableMap(Map)}. Later
+     *         modifications of this builder therefore do not affect the returned
+     *         map
      */
     public Map<K, V> toImmutableMap() {
-        return Collections.unmodifiableMap(collector);
+        return Collections.unmodifiableMap(new HashMap<>(collector));
     }
 
     /**

--- a/src/main/java/de/cuioss/tools/collect/MapDifferenceImpl.java
+++ b/src/main/java/de/cuioss/tools/collect/MapDifferenceImpl.java
@@ -16,12 +16,13 @@
 package de.cuioss.tools.collect;
 
 import de.cuioss.tools.collect.MapDifference.ValueDifference;
-import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
@@ -30,9 +31,8 @@ import static java.util.Objects.requireNonNull;
  *
  */
 @RequiredArgsConstructor
-@EqualsAndHashCode
 @ToString
-class MapDiffenceImpl<K, V> implements MapDifference<K, V> {
+class MapDifferenceImpl<K, V> implements MapDifference<K, V> {
 
     private final Map<K, V> entriesOnlyOnRight;
     private final Map<K, V> entriesOnlyOnLeft;
@@ -62,6 +62,43 @@ class MapDiffenceImpl<K, V> implements MapDifference<K, V> {
     @Override
     public Map<K, ValueDifference<V>> entriesDiffering() {
         return entriesDiffering;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Implemented as defined by {@link MapDifference#equals(Object)}: two
+     * instances are equal if the given object is also a {@link MapDifference}
+     * and the values returned by {@link #entriesOnlyOnLeft()},
+     * {@link #entriesOnlyOnRight()}, {@link #entriesInCommon()} and
+     * {@link #entriesDiffering()} of the two instances are equal.
+     * </p>
+     */
+    @Override
+    public boolean equals(Object object) {
+        if (object == this) {
+            return true;
+        }
+        if (object instanceof MapDifference<?, ?> other) {
+            return entriesOnlyOnLeft().equals(other.entriesOnlyOnLeft())
+                    && entriesOnlyOnRight().equals(other.entriesOnlyOnRight())
+                    && entriesInCommon().equals(other.entriesInCommon())
+                    && entriesDiffering().equals(other.entriesDiffering());
+        }
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Implemented as defined by {@link MapDifference#hashCode()}:
+     * {@code Arrays.asList(entriesOnlyOnLeft(), entriesOnlyOnRight(), entriesInCommon(), entriesDiffering()).hashCode()}
+     * </p>
+     */
+    @Override
+    public int hashCode() {
+        return Arrays.asList(entriesOnlyOnLeft(), entriesOnlyOnRight(), entriesInCommon(), entriesDiffering())
+                .hashCode();
     }
 
     /**
@@ -97,7 +134,7 @@ class MapDiffenceImpl<K, V> implements MapDifference<K, V> {
         sortEntriesToBucket(left, right, onlyLeft, common, entriesDiffering);
         // now from the other direction.
         sortEntriesToBucket(right, left, onlyRight, common, entriesDiffering);
-        return new MapDiffenceImpl<>(onlyRight.toImmutableMap(), onlyLeft.toImmutableMap(), common.toImmutableMap(),
+        return new MapDifferenceImpl<>(onlyRight.toImmutableMap(), onlyLeft.toImmutableMap(), common.toImmutableMap(),
                 entriesDiffering.toImmutableMap());
     }
 
@@ -149,5 +186,42 @@ class ValueDifferenceImpl<V> implements ValueDifference<V> {
     @Override
     public V rightValue() {
         return rightValue;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Implemented as defined by {@link ValueDifference#equals(Object)}: two
+     * instances are considered equal if their {@link #leftValue()} values are
+     * equal and their {@link #rightValue()} values are also equal.
+     * </p>
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (other instanceof ValueDifference<?> otherDifference) {
+            return Objects.equals(leftValue, otherDifference.leftValue())
+                    && Objects.equals(rightValue, otherDifference.rightValue());
+        }
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Implemented as defined by {@link ValueDifference#hashCode()}:
+     * {@code Arrays.asList(leftValue(), rightValue()).hashCode()}
+     * </p>
+     */
+    @Override
+    public int hashCode() {
+        return Arrays.asList(leftValue, rightValue).hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "(" + leftValue + ", " + rightValue + ")";
     }
 }

--- a/src/main/java/de/cuioss/tools/collect/MapDifferenceImpl.java
+++ b/src/main/java/de/cuioss/tools/collect/MapDifferenceImpl.java
@@ -19,7 +19,6 @@ import de.cuioss.tools.collect.MapDifference.ValueDifference;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -97,8 +96,14 @@ class MapDifferenceImpl<K, V> implements MapDifference<K, V> {
      */
     @Override
     public int hashCode() {
-        return Arrays.asList(entriesOnlyOnLeft(), entriesOnlyOnRight(), entriesInCommon(), entriesDiffering())
-                .hashCode();
+        // Allocation-free equivalent of
+        // Arrays.asList(entriesOnlyOnLeft(), entriesOnlyOnRight(), entriesInCommon(), entriesDiffering()).hashCode()
+        var result = 1;
+        result = 31 * result + entriesOnlyOnLeft().hashCode();
+        result = 31 * result + entriesOnlyOnRight().hashCode();
+        result = 31 * result + entriesInCommon().hashCode();
+        result = 31 * result + entriesDiffering().hashCode();
+        return result;
     }
 
     /**
@@ -217,7 +222,11 @@ class ValueDifferenceImpl<V> implements ValueDifference<V> {
      */
     @Override
     public int hashCode() {
-        return Arrays.asList(leftValue, rightValue).hashCode();
+        // Allocation-free equivalent of Arrays.asList(leftValue, rightValue).hashCode()
+        var result = 1;
+        result = 31 * result + (leftValue == null ? 0 : leftValue.hashCode());
+        result = 31 * result + (rightValue == null ? 0 : rightValue.hashCode());
+        return result;
     }
 
     @Override

--- a/src/main/java/de/cuioss/tools/collect/MoreCollections.java
+++ b/src/main/java/de/cuioss/tools/collect/MoreCollections.java
@@ -57,6 +57,12 @@ public final class MoreCollections {
     /**
      * Simple check method for a {@code null} safe check of the emptiness of the
      * given varags-parameter.
+     * <p>
+     * <em>Caution:</em> Do not pass a primitive array (e.g. {@code byte[]})
+     * directly: it will be wrapped by the varargs mechanism as a single element
+     * of the {@code Object[]} and is therefore never considered empty, no matter
+     * how many elements the primitive array itself contains.
+     * </p>
      *
      * @param elements to be checked may be null
      * @return {@code true} is the given elements are {@code null} or {@code empty}
@@ -334,7 +340,7 @@ public final class MoreCollections {
     // This is proper encapsulation with a package-private implementation class.
     public static <K, V> MapDifference<K, V> difference(Map<? extends K, ? extends V> left,
             Map<? extends K, ? extends V> right) {
-        return MapDiffenceImpl.from(left, right);
+        return MapDifferenceImpl.from(left, right);
     }
 
 }

--- a/src/main/java/de/cuioss/tools/collect/PartialArrayList.java
+++ b/src/main/java/de/cuioss/tools/collect/PartialArrayList.java
@@ -15,7 +15,6 @@
  */
 package de.cuioss.tools.collect;
 
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -33,10 +32,17 @@ import java.util.List;
  * <p>
  * See {@link PartialArrayList#of(List, int)}
  * </p>
+ * <h3>Equality</h3>
+ * <p>
+ * {@code equals} and {@code hashCode} are inherited from {@link ArrayList} and
+ * therefore follow the {@link List} contract: the {@link #isMoreAvailable()}
+ * flag is deliberately <em>not</em> part of {@code equals} / {@code hashCode},
+ * keeping equality symmetric with any other {@link List} containing the same
+ * elements.
+ * </p>
  *
  * @param <T> at least {@link Serializable}
  */
-@EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class PartialArrayList<T extends Serializable> extends ArrayList<T> implements PartialCollection<T> {
 

--- a/src/main/java/de/cuioss/tools/collect/package-info.java
+++ b/src/main/java/de/cuioss/tools/collect/package-info.java
@@ -54,10 +54,10 @@
  * Map&lt;String, Integer&gt; right = MapBuilder.from("b", 2).put("c", 3).toImmutableMap();
  * MapDifference difference = MoreCollections.difference(left, right);
  *
- * // Using partial collections
+ * // Using partial collections (snapshot copy of the first elements, not a view)
  * List&lt;String&gt; originalList = Arrays.asList("a", "b", "c", "d", "e");
- * List&lt;String&gt; partialView = new PartialArrayList&lt;&gt;(originalList, 0, 3);
- * // partialView contains ["a", "b", "c"]
+ * List&lt;String&gt; partial = PartialArrayList.of(originalList, 3);
+ * // partial contains ["a", "b", "c"], isMoreAvailable() == true
  * </pre>
  *
  * <h2>Best Practices</h2>

--- a/src/test/java/de/cuioss/tools/collect/CollectionBuilderTest.java
+++ b/src/test/java/de/cuioss/tools/collect/CollectionBuilderTest.java
@@ -155,6 +155,15 @@ class CollectionBuilderTest {
             assertNotNull(builder.toArray(String.class));
             assertEquals(5, builder.toArray(String.class).length);
         }
+
+        @Test
+        @DisplayName("convert to array with the exact component type")
+        void shouldReturnTypedArray() {
+            final var builder = new CollectionBuilder<String>().add("1", "2");
+            final var array = builder.toArray(String.class);
+            assertEquals(String[].class, array.getClass());
+            assertArrayEquals(new String[]{"1", "2"}, array);
+        }
     }
 
     @Nested
@@ -208,6 +217,13 @@ class CollectionBuilderTest {
             final CollectionBuilder<String> builder = CollectionBuilder.copyFrom("1");
             builder.add("4");
             assertEquals(2, builder.toConcurrentNavigableSet().size());
+        }
+
+        @Test
+        @DisplayName("copy from null single parameter results in empty builder")
+        void shouldCreateEmptyBuilderFromNullSingleParam() {
+            final CollectionBuilder<String> builder = CollectionBuilder.copyFrom((String) null);
+            assertTrue(builder.isEmpty());
         }
     }
 

--- a/src/test/java/de/cuioss/tools/collect/CollectionLiteralsTest.java
+++ b/src/test/java/de/cuioss/tools/collect/CollectionLiteralsTest.java
@@ -143,6 +143,14 @@ class CollectionLiteralsTest {
         }
 
         @Test
+        @DisplayName("Should return empty mutable list for null single element")
+        void shouldReturnEmptyMutableListForNullElement() {
+            var list = mutableList((String) null);
+            assertTrue(list.isEmpty(), "null element must not be added");
+            assertMutable(list);
+        }
+
+        @Test
         @DisplayName("Should handle immutable list operations")
         void shouldHandleImmutableList() {
             assertImmutable(immutableList());
@@ -251,11 +259,25 @@ class CollectionLiteralsTest {
         @DisplayName("Should handle immutable map operations")
         void shouldHandleImmutableMap() {
             assertImmutable(immutableMap());
+            assertImmutable(immutableMap((Map<String, String>) null));
             assertImmutable(immutableMap(mutableMap("1", "2")));
             assertImmutable(immutableMap("1", "2"));
             assertImmutable(immutableMap("1", "1-1", "2", "2-2"));
             assertImmutable(immutableMap("1", "1-1", "2", "2-2", "3", "3-3"));
             assertImmutable(immutableMap("1", "1-1", "2", "2-2", "3", "3-3", "4", "4-4"));
+        }
+
+        @Test
+        @DisplayName("Should copy source map for immutable map")
+        void shouldCopySourceMapForImmutableMap() {
+            var source = mutableMap("1", "1-1");
+            var immutable = immutableMap(source);
+
+            source.put("2", "2-2");
+            source.remove("1");
+
+            assertEquals(1, immutable.size());
+            assertEquals("1-1", immutable.get("1"));
         }
 
         @Test

--- a/src/test/java/de/cuioss/tools/collect/MapBuilderTest.java
+++ b/src/test/java/de/cuioss/tools/collect/MapBuilderTest.java
@@ -108,6 +108,19 @@ class MapBuilderTest {
     }
 
     @Test
+    void toImmutableMapShouldNotBeAffectedByLaterBuilderChanges() {
+        var builder = new MapBuilder<String, String>().put(KEY_1, VALUE_1);
+        var immutable = builder.toImmutableMap();
+
+        builder.put(KEY_2, VALUE_2);
+        builder.remove(KEY_1);
+        builder.clear();
+
+        assertEquals(1, immutable.size());
+        assertEquals(VALUE_1, immutable.get(KEY_1));
+    }
+
+    @Test
     void shouldOnlyAddIfNotNull() {
         final var map = new MapBuilder<String, String>().put(KEY_1, null).putIfNotNull(KEY_2, null)
                 .putIfNotNull(KEY_3, "").toImmutableMap();

--- a/src/test/java/de/cuioss/tools/collect/MoreCollectionsTest.java
+++ b/src/test/java/de/cuioss/tools/collect/MoreCollectionsTest.java
@@ -17,6 +17,7 @@ package de.cuioss.tools.collect;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -40,14 +41,11 @@ class MoreCollectionsTest {
         assertTrue(isEmpty((Object[]) null));
 
         requireNotEmpty("1");
-        requireNotEmpty(Integer.valueOf(0), MESSAGE);
-    }
-
-    void shouldDetermineEmptinessForArrays() {
-        assertFalse(isEmpty(new byte[]{Byte.MIN_VALUE}));
-        assertFalse(isEmpty(new byte[]{Byte.MIN_VALUE, Byte.MAX_VALUE}));
-        assertTrue(isEmpty((byte[]) null));
-        assertTrue(isEmpty(new byte[0]));
+        assertArrayEquals(new Integer[]{0, 1}, requireNotEmpty(Integer.valueOf(0), Integer.valueOf(1)));
+        assertThrows(IllegalArgumentException.class, () ->
+                requireNotEmpty((Object[]) null));
+        assertThrows(IllegalArgumentException.class, () ->
+                requireNotEmpty(new Object[0]));
     }
 
     @Test
@@ -223,6 +221,49 @@ class MoreCollectionsTest {
         assertTrue(diff.entriesInCommon().isEmpty());
         assertTrue(diff.entriesOnlyOnLeft().isEmpty());
         assertTrue(diff.entriesOnlyOnRight().isEmpty());
+    }
+
+    @Test
+    void differenceShouldImplementDocumentedEqualsAndHashCodeContract() {
+        Map<String, String> left = immutableMap("key", "value", "left", "leftOnly", "differing", "valueLeft");
+        Map<String, String> right = immutableMap("key", "value", "right", "rightOnly", "differing", "valueRight");
+
+        MapDifference<String, String> diff = difference(left, right);
+        MapDifference<String, String> sameDiff = difference(mutableMap("key", "value", "left", "leftOnly",
+                "differing", "valueLeft"), mutableMap("key", "value", "right", "rightOnly", "differing", "valueRight"));
+        MapDifference<String, String> otherDiff = difference(left, immutableMap("key", "value"));
+
+        assertEquals(diff, diff);
+        assertEquals(diff, sameDiff);
+        assertEquals(sameDiff, diff);
+        assertEquals(diff.hashCode(), sameDiff.hashCode());
+        assertEquals(Arrays.asList(diff.entriesOnlyOnLeft(), diff.entriesOnlyOnRight(), diff.entriesInCommon(),
+                diff.entriesDiffering()).hashCode(), diff.hashCode());
+
+        assertNotEquals(diff, otherDiff);
+        assertNotEquals(diff, "someString");
+        assertNotEquals(null, diff);
+    }
+
+    @Test
+    void valueDifferenceShouldImplementDocumentedEqualsAndHashCodeContract() {
+        var difference = difference(immutableMap("key", "value1"), immutableMap("key", "value2"))
+                .entriesDiffering().get("key");
+        var sameDifference = difference(immutableMap("key", "value1"), immutableMap("key", "value2"))
+                .entriesDiffering().get("key");
+        var otherDifference = difference(immutableMap("key", "value1"), immutableMap("key", "value3"))
+                .entriesDiffering().get("key");
+
+        assertEquals(difference, difference);
+        assertEquals(difference, sameDifference);
+        assertEquals(sameDifference, difference);
+        assertEquals(difference.hashCode(), sameDifference.hashCode());
+        assertEquals(Arrays.asList("value1", "value2").hashCode(), difference.hashCode());
+
+        assertNotEquals(difference, otherDifference);
+        assertNotEquals(difference, "someString");
+        assertNotEquals(null, difference);
+        assertNotNull(difference.toString());
     }
 
     @Test

--- a/src/test/java/de/cuioss/tools/collect/PartialArrayListTest.java
+++ b/src/test/java/de/cuioss/tools/collect/PartialArrayListTest.java
@@ -73,4 +73,22 @@ class PartialArrayListTest {
     void shouldImplementObjectContracts() {
         ObjectMethodsAsserts.assertNiceObject(of(randomStrings(4), 4));
     }
+
+    @Test
+    void shouldProvideSymmetricEqualityWithPlainLists() {
+        var content = randomStrings(4);
+        var plainList = new ArrayList<>(content);
+        var partial = of(content, DEFAULT_SIZE);
+        var partialMoreAvailable = of(content, content.size() - 1);
+
+        // List contract: equality is symmetric and ignores isMoreAvailable()
+        assertEquals(plainList, partial);
+        assertEquals(partial, plainList);
+        assertEquals(plainList.hashCode(), partial.hashCode());
+
+        var truncatedPlainList = new ArrayList<>(content.subList(0, content.size() - 1));
+        assertEquals(truncatedPlainList, partialMoreAvailable);
+        assertEquals(partialMoreAvailable, truncatedPlainList);
+        assertEquals(truncatedPlainList.hashCode(), partialMoreAvailable.hashCode());
+    }
 }


### PR DESCRIPTION
## Summary

Cluster C of the project-analysis fix series (findings catalog: `doc/analysis-findings.md`, IDs COL-1..COL-19).

- **COL-1 (high)**: `ValueDifferenceImpl` had identity equals/hashCode, breaking the documented `MapDifference.ValueDifference` contract — two `MapDifference`s computed from the same map pairs were never equal when any entry differed. Now implements the documented value-based equals, the exact documented hashCode formula, and a readable `toString`.
- **COL-16/COL-17**: renamed `MapDiffenceImpl` → `MapDifferenceImpl` (typo) and replaced the Lombok-generated equals/hashCode with implementations matching the documented `MapDifference` interface contract.
- **COL-2**: removed `@EqualsAndHashCode(callSuper = true)` from `PartialArrayList` — it produced asymmetric equals vs. plain lists (violating the `List` contract); now inherits `ArrayList` semantics, with `isMoreAvailable` documented as deliberately excluded.
- **COL-5/COL-7**: `MapBuilder.toImmutableMap()` and `CollectionLiterals.immutableMap(Map)` returned live *views* — later mutations of the builder/source map changed the "immutable" result. Both now copy before wrapping; `immutableMap(Map)` also tolerates null like its siblings.
- **COL-6/COL-9**: `mutableList(E)` (and thereby `CollectionBuilder.copyFrom(E)`) kept a null element while every sibling single-element factory drops null — now consistent.
- **COL-8**: `CollectionBuilder.toArray(Class<? super E>)` → `Class<E>`; the supertype bound invited `ClassCastException` at call sites.
- **COL-4, COL-10..COL-15**: javadoc corrections (non-compiling package example, copy-pasted references, "mutable"/"HashSet" claims that say the opposite of the implementation, nonexistent null/empty constraints).
- **COL-3, COL-18, COL-19 (tests)**: removed a never-run, would-fail test (`@Test` missing) and documented the primitive-array varargs pitfall it exposed; fixed an assertion that silently absorbed its message into varargs; added contract tests for MapDifference/ValueDifference equality, `toImmutableMap` aliasing, symmetric PartialArrayList equality, and `toArray`.

## Test plan

- `./mvnw clean install` — BUILD SUCCESS, 804 tests, 0 failures/errors/skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKzn4Upj33uRFvWQep3UzE

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKzn4Upj33uRFvWQep3UzE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collection helpers now treat `null` inputs consistently, returning empty collections where appropriate.
* **Bug Fixes**
  * Immutable map creation now produces an actual snapshot that remains unchanged after later builder modifications.
  * Map difference and value difference now follow documented `equals`, `hashCode`, and `toString` behavior.
  * Partial collection equality now aligns with normal list equality semantics.
* **Documentation**
  * Updated Javadocs and examples; clarified varargs/`null` behavior.
* **Tests**
  * Added coverage for `null` handling, immutability snapshots, and array typing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->