### PR TITLE
string/formatting: fix template static text, splitter semantics and doc drift

### DIFF
--- a/src/main/java/de/cuioss/tools/formatting/SimpleFormatter.java
+++ b/src/main/java/de/cuioss/tools/formatting/SimpleFormatter.java
@@ -15,6 +15,7 @@
  */
 package de.cuioss.tools.formatting;
 
+import de.cuioss.tools.string.MoreStrings;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
@@ -108,7 +109,7 @@ public class SimpleFormatter implements Serializable {
         if (isEmpty(values)) {
             return null;
         }
-        var filtered = values.stream().filter(element -> !isEmpty(element)).toList();
+        var filtered = values.stream().filter(element -> !MoreStrings.isEmpty(element)).toList();
         if (isEmpty(filtered)) {
             return null;
         }

--- a/src/main/java/de/cuioss/tools/formatting/template/TemplateFormatterImpl.java
+++ b/src/main/java/de/cuioss/tools/formatting/template/TemplateFormatterImpl.java
@@ -110,17 +110,41 @@ public final class TemplateFormatterImpl<T extends FormatterSupport> implements 
     /**
      * Determines whether the string token at the given index should be part of the
      * output. A string token without a preceding attribute token (leading literal)
-     * only requires a following attribute with a value, a string token without a
-     * following attribute token (trailing literal) only requires a preceding
-     * attribute with a value. String tokens between attributes require both, in
-     * order to suppress useless separators.
+     * only requires some following attribute with a value, a string token without a
+     * following attribute token (trailing literal) only requires some preceding
+     * attribute with a value. String tokens between attributes require the
+     * immediately preceding attribute and some following attribute to have values,
+     * in order to suppress useless separators.
      */
     private boolean shouldEmitStringToken(final List<Token> tokenList, final T reference, final int index) {
-        final var precedingHasValue = !containsAttributeToken(tokenList, 0, index)
-                || lookUpLastTokenHasValue(tokenList, reference, index);
-        final var followingHasValue = !containsAttributeToken(tokenList, index + 1, tokenList.size())
-                || lookUpNextTokenHasValue(tokenList, reference, index);
-        return precedingHasValue && followingHasValue;
+        final var hasAttributeBefore = containsAttributeToken(tokenList, 0, index);
+        final var hasAttributeAfter = containsAttributeToken(tokenList, index + 1, tokenList.size());
+        if (!hasAttributeBefore && !hasAttributeAfter) {
+            // Template consists of literal text only
+            return true;
+        }
+        if (!hasAttributeBefore) {
+            // Leading literal
+            return lookUpNextTokenHasValue(tokenList, reference, index);
+        }
+        if (!hasAttributeAfter) {
+            // Trailing literal: any preceding attribute with a value qualifies
+            return anyPrecedingAttributeHasValue(tokenList, reference, index);
+        }
+        // Separator between attributes: keep the established suppression semantics
+        return lookUpLastTokenHasValue(tokenList, reference, index)
+                && lookUpNextTokenHasValue(tokenList, reference, index);
+    }
+
+    private boolean anyPrecedingAttributeHasValue(final List<Token> tokenList, final T reference,
+            final int currentTokenIndex) {
+        for (var index = currentTokenIndex - 1; index >= 0; index--) {
+            final var token = tokenList.get(index);
+            if (!token.isStringToken() && !token.substituteAttribute(reference).isEmpty()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static boolean containsAttributeToken(final List<Token> tokenList, final int fromInclusive,

--- a/src/main/java/de/cuioss/tools/formatting/template/TemplateFormatterImpl.java
+++ b/src/main/java/de/cuioss/tools/formatting/template/TemplateFormatterImpl.java
@@ -74,6 +74,11 @@ public final class TemplateFormatterImpl<T extends FormatterSupport> implements 
     /**
      * replace attributes from template by attribute values from the map. missing
      * template attributes will be ignored and doesn't add to result at all.
+     * Literal (static) text appears as-is in the output: leading static text is
+     * emitted if the following attribute produces a value, trailing static text
+     * if the preceding attribute produced a value, and static text between two
+     * attributes only if the preceding attribute produced a value and a following
+     * attribute produces a value (separator suppression).
      *
      * @param reference must not be null
      *
@@ -91,8 +96,7 @@ public final class TemplateFormatterImpl<T extends FormatterSupport> implements 
         for (var index = 0; index < tokenList.size(); index++) {
             final var token = tokenList.get(index);
             if (token.isStringToken()) {
-                if (lookUpLastTokenHasValue(tokenList, reference, index)
-                        && lookUpNextTokenHasValue(tokenList, reference, index)) {
+                if (shouldEmitStringToken(tokenList, reference, index)) {
                     buffer.append(token.substituteAttribute(reference));
                 }
             } else {
@@ -101,6 +105,32 @@ public final class TemplateFormatterImpl<T extends FormatterSupport> implements 
         }
 
         return buffer.toString();
+    }
+
+    /**
+     * Determines whether the string token at the given index should be part of the
+     * output. A string token without a preceding attribute token (leading literal)
+     * only requires a following attribute with a value, a string token without a
+     * following attribute token (trailing literal) only requires a preceding
+     * attribute with a value. String tokens between attributes require both, in
+     * order to suppress useless separators.
+     */
+    private boolean shouldEmitStringToken(final List<Token> tokenList, final T reference, final int index) {
+        final var precedingHasValue = !containsAttributeToken(tokenList, 0, index)
+                || lookUpLastTokenHasValue(tokenList, reference, index);
+        final var followingHasValue = !containsAttributeToken(tokenList, index + 1, tokenList.size())
+                || lookUpNextTokenHasValue(tokenList, reference, index);
+        return precedingHasValue && followingHasValue;
+    }
+
+    private static boolean containsAttributeToken(final List<Token> tokenList, final int fromInclusive,
+            final int toExclusive) {
+        for (var index = fromInclusive; index < toExclusive; index++) {
+            if (!tokenList.get(index).isStringToken()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean lookUpNextTokenHasValue(final List<Token> tokenList, final T reference,

--- a/src/main/java/de/cuioss/tools/formatting/template/Validator.java
+++ b/src/main/java/de/cuioss/tools/formatting/template/Validator.java
@@ -40,8 +40,13 @@ public class Validator<F extends FormatterSupport> implements Serializable {
     }
 
     /**
-     * @param template must not be null if the template doesn't fit to el-expression or
-     *                 use tokens which are not supported.
+     * Validates the given template with the configured {@link Lexer}.
+     *
+     * @param template the template to validate, must not be null
+     * @throws NullPointerException     if template is null
+     * @throws IllegalArgumentException if the template doesn't fit the expression
+     *                                  language or uses tokens which are not
+     *                                  supported
      */
     public void validate(final String template) {
         requireNonNull(template, "Template must not be null.");

--- a/src/main/java/de/cuioss/tools/formatting/template/lexer/BracketLexer.java
+++ b/src/main/java/de/cuioss/tools/formatting/template/lexer/BracketLexer.java
@@ -78,10 +78,6 @@ class BracketLexer<T extends FormatterSupport> extends Lexer<T> {
             rightBracket = right;
         }
 
-        List<String> splitByLeftBracket(final String input) {
-            return Splitter.on(leftBracket).omitEmptyStrings().splitToList(input);
-        }
-
         List<String> splitByRightBracket(final String input) {
             return Splitter.on(rightBracket).omitEmptyStrings().splitToList(input);
         }
@@ -136,18 +132,13 @@ class BracketLexer<T extends FormatterSupport> extends Lexer<T> {
 
         if (!isEmpty(input)) {
 
-            final var chunksSplitByLeftBracket = brackets.splitByLeftBracket(input);
-            final var chunksSplitByRightBracket = brackets.splitByRightBracket(input);
-            var leftBracketCount = MoreStrings.countMatches(input, String.valueOf(brackets.leftBracket));
-            var rightBracketCount = MoreStrings.countMatches(input, String.valueOf(brackets.rightBracket));
-            var chunkCountEven = chunksSplitByLeftBracket.size() == chunksSplitByRightBracket.size();
-            var bracketCountEven = leftBracketCount == rightBracketCount;
-            // Assumption: Static elements are implicitly filtered
-            checkArgument(chunkCountEven && bracketCountEven,
-                    "pattern '%s' is unbalanced for %s, left-hand:%s, right-hand:%s", input, brackets,
-                    chunksSplitByLeftBracket, chunksSplitByRightBracket);
+            final var leftBracketCount = MoreStrings.countMatches(input, String.valueOf(brackets.leftBracket));
+            final var rightBracketCount = MoreStrings.countMatches(input, String.valueOf(brackets.rightBracket));
+            checkArgument(leftBracketCount == rightBracketCount,
+                    "pattern '%s' is unbalanced for %s, left bracket count:%s, right bracket count:%s", input,
+                    brackets, leftBracketCount, rightBracketCount);
 
-            for (final String chunk : chunksSplitByRightBracket) {
+            for (final String chunk : brackets.splitByRightBracket(input)) {
                 if (!isEmpty(chunk)) {
                     parseChunk(chunk, tokens);
                 }

--- a/src/main/java/de/cuioss/tools/formatting/template/lexer/Lexer.java
+++ b/src/main/java/de/cuioss/tools/formatting/template/lexer/Lexer.java
@@ -105,20 +105,18 @@ public abstract class Lexer<T extends FormatterSupport> implements Serializable 
      * Supported expression language
      */
     public enum ExpressionLanguage {
-        /** {@code [attribute1][attribute2]..[attribute n]} */
+        /**
+         * {@code [attribute1][attribute2]..[attribute n]}
+         * <p>
+         * Note: the constant name contains a typo ("BRACKTES" instead of
+         * "BRACKETS"). It is kept as-is because renaming it would be a breaking
+         * API change.
+         */
         SIMPLE_SQUARED_BRACKTES,
         /** {attribute1}{attribute2}..{attribute n} */
         SIMPLE_CURLY_BRACKETS,
         /** {@code <attribute1><attribute2>..<attribute n>} */
-        SIMPLE_ANGLE_BRACKET,
-        /**
-         * usage of String Template Expression Language
-         *
-         * @see <a href=
-         *      "http://www.antlr.org/wiki/display/ST/StringTemplate+3+Documentation">
-         *      Documentation</a>
-         */
-        STEL
+        SIMPLE_ANGLE_BRACKET
     }
 
 }

--- a/src/main/java/de/cuioss/tools/formatting/template/lexer/package-info.java
+++ b/src/main/java/de/cuioss/tools/formatting/template/lexer/package-info.java
@@ -37,10 +37,10 @@
  * 
  * <h2>Usage Example</h2>
  * <pre>
- * Lexer lexer = LexerBuilder.create()
- *     .withTemplate("[firstName] [lastName]")
- *     .build();
- * List&lt;Token&gt; tokens = lexer.tokenize();
+ * // Given a bean type implementing FormatterSupport:
+ * Lexer&lt;PersonName&gt; lexer = LexerBuilder.useSimpleElWithSquaredBrackets()
+ *         .build(PersonName.class);
+ * List&lt;Token&gt; tokens = lexer.scan("[firstName] [lastName]");
  * </pre>
  * 
  * @author Eugen Fischer

--- a/src/main/java/de/cuioss/tools/formatting/template/package-info.java
+++ b/src/main/java/de/cuioss/tools/formatting/template/package-info.java
@@ -32,7 +32,10 @@
  * 
  * <h2>Usage Example</h2>
  * <pre>{@code
- * // Example code here
+ * // Given a bean type PersonName implementing FormatterSupport:
+ * TemplateFormatter<PersonName> formatter = TemplateFormatterImpl.createFormatter(
+ *         "[givenName] [familyName]", PersonName.class);
+ * String formatted = formatter.format(personName);
  * }</pre>
  * 
  * @see de.cuioss.tools.formatting.template.FormatterSupport

--- a/src/main/java/de/cuioss/tools/formatting/template/token/ActionToken.java
+++ b/src/main/java/de/cuioss/tools/formatting/template/token/ActionToken.java
@@ -21,8 +21,6 @@ import lombok.ToString;
 
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 
 import static de.cuioss.tools.base.Preconditions.checkArgument;
@@ -49,23 +47,16 @@ public class ActionToken implements Token {
     private final String after;
 
     /**
-     * @param template
-     * @param token
+     * @param template the template chunk containing the attribute name, must contain {@code token}
+     * @param token    the attribute name, treated as a literal string, not as a
+     *                 regular expression
      */
     public ActionToken(final String template, final String token) {
-        checkArgument(template.contains(token), "'" + template + " must contain '" + token + "'");
-        final List<String> splitted = Arrays.asList(template.split(token));
-        before = extractSurrounding(splitted, 0);
+        final var tokenIndex = template.indexOf(token);
+        checkArgument(tokenIndex >= 0, "'" + template + "' must contain '" + token + "'");
+        before = template.substring(0, tokenIndex);
         attribute = token;
-        after = extractSurrounding(splitted, 1);
-    }
-
-    private static String extractSurrounding(final List<String> splitted, final int index) {
-        var result = "";
-        if (!splitted.isEmpty() && splitted.size() > index) {
-            result = splitted.get(index);
-        }
-        return result;
+        after = template.substring(tokenIndex + token.length());
     }
 
     @Override

--- a/src/main/java/de/cuioss/tools/formatting/template/token/package-info.java
+++ b/src/main/java/de/cuioss/tools/formatting/template/token/package-info.java
@@ -38,9 +38,9 @@
  * <pre>
  * // A template like "[firstName] [lastName]" would be tokenized into:
  * List&lt;Token&gt; tokens = Arrays.asList(
- *     new ActionToken("firstName"),
+ *     new ActionToken("firstName", "firstName"),
  *     new StringToken(" "),
- *     new ActionToken("lastName")
+ *     new ActionToken("lastName", "lastName")
  * );
  * </pre>
  * 

--- a/src/main/java/de/cuioss/tools/string/MoreStrings.java
+++ b/src/main/java/de/cuioss/tools/string/MoreStrings.java
@@ -127,7 +127,7 @@ import java.util.logging.Logger;
  * <h3>4. String Search and Manipulation</h3>
  * <pre>
  * // Searching
- * assertEquals(2, countMatches("banana", "a"));
+ * assertEquals(3, countMatches("banana", "a"));
  * assertEquals(1, indexOf("hello", 'e'));
  *
  * // Manipulation
@@ -225,6 +225,7 @@ public final class MoreStrings {
      * <pre>
      * unquote(null)      = null
      * unquote("")        = ""
+     * unquote("'")       = "'"
      * unquote("'text'")  = "text"
      * unquote("\"text\"") = "text"
      * unquote("text")    = "text"
@@ -234,7 +235,7 @@ public final class MoreStrings {
      * @return the unquoted String, or the original if no quotes were found or input was null/empty
      */
     public static String unquote(final String original) {
-        if (isEmpty(original)) {
+        if (isEmpty(original) || original.length() < 2) {
             return original;
         }
         if (original.startsWith("\"") && original.endsWith("\"")
@@ -356,9 +357,10 @@ public final class MoreStrings {
      * </p>
      *
      * <pre>
-     * MoreStrings.isEmpty(null)      = false
-     * MoreStrings.isEmpty("")        = false
-     * MoreStrings.isEmpty(" ")       = true
+     * MoreStrings.isPresent(null)      = false
+     * MoreStrings.isPresent("")        = false
+     * MoreStrings.isPresent(" ")       = true
+     * MoreStrings.isPresent("bob")     = true
      * </pre>
      *
      * @param cs the CharSequence to check, may be null
@@ -391,8 +393,14 @@ public final class MoreStrings {
      * MoreStrings.isNumeric("")     = false
      * MoreStrings.isNumeric("  ")   = false
      * MoreStrings.isNumeric("123")  = true
-     * MoreStrings.isNumeric("१२३")  = true MoreStrings.isNumeric("12 3") = false MoreStrings.isNumeric("ab2c") = false MoreStrings.isNumeric("12-3") = false MoreStrings.isNumeric("12.3") = false MoreStrings.isNumeric("-123") = false MoreStrings.isNumeric("+123") = false
-     * </pre >
+     * MoreStrings.isNumeric("१२३")  = true
+     * MoreStrings.isNumeric("12 3") = false
+     * MoreStrings.isNumeric("ab2c") = false
+     * MoreStrings.isNumeric("12-3") = false
+     * MoreStrings.isNumeric("12.3") = false
+     * MoreStrings.isNumeric("-123") = false
+     * MoreStrings.isNumeric("+123") = false
+     * </pre>
      *
      * <p>
      * Inspired by Apache Commons Lang StringUtils.
@@ -463,11 +471,11 @@ public final class MoreStrings {
      * </p>
      *
      * <pre>
-     * MoreStrings.isBlank(null)      = false
-     * MoreStrings.isBlank("")        = false
-     * MoreStrings.isBlank(" ")       = false
-     * MoreStrings.isBlank("bob")     = true
-     * MoreStrings.isBlank("  bob  ") = true
+     * MoreStrings.isNotBlank(null)      = false
+     * MoreStrings.isNotBlank("")        = false
+     * MoreStrings.isNotBlank(" ")       = false
+     * MoreStrings.isNotBlank("bob")     = true
+     * MoreStrings.isNotBlank("  bob  ") = true
      * </pre>
      *
      * @param cs to be checked
@@ -1163,7 +1171,6 @@ public final class MoreStrings {
             }
             builder.append(']');
         }
-        LOGGER.log(Level.FINE, () -> "No args given, returning template " + templateString);
         return builder.toString();
     }
 
@@ -1173,8 +1180,6 @@ public final class MoreStrings {
      * @return value with suffix
      */
     public static String ensureEndsWith(@NonNull final String value, @NonNull final String suffix) {
-        Objects.requireNonNull(value, "value must not be null");
-        Objects.requireNonNull(suffix, "suffix must not be null");
         if (!value.endsWith(suffix)) {
             return value + suffix;
         }
@@ -1212,11 +1217,19 @@ public final class MoreStrings {
     }
 
     /**
-     * @param checker the predicate to check each given value against. it decides if
-     *                a value qualifies to be returned.
-     * @param values  to be evaluated
-     * @return first string that is accepted by the given {@link Predicate} or
-     * {@link Optional#empty()}
+     * Returns the first value that is <em>not rejected</em> by the given
+     * {@link Predicate}. The predicate acts as a rejector: a value qualifies if
+     * {@code checker.test(value)} returns {@code false}. E.g.
+     * {@link #firstNonEmpty(String...)} passes {@link #isEmpty(CharSequence)} as
+     * rejector in order to skip empty values.
+     *
+     * @param checker the rejecting predicate; a value is returned if the predicate
+     *                evaluates to {@code false} for it. Must not be null
+     * @param values  to be evaluated, may be null
+     * @return an {@link Optional} on the first value that is not rejected by the
+     * given {@link Predicate}, or {@link Optional#empty()} if all values are
+     * rejected or {@code values} is null. Note: if the first non-rejected
+     * value is {@code null}, {@link Optional#empty()} is returned as well
      */
     @NonNull
     public static Optional<String> coalesce(Predicate<String> checker, String... values) {
@@ -1224,7 +1237,7 @@ public final class MoreStrings {
         if (null != values) {
             for (String value : values) {
                 if (!checker.test(value)) {
-                    return Optional.of(value);
+                    return Optional.ofNullable(value);
                 }
             }
         }

--- a/src/main/java/de/cuioss/tools/string/Splitter.java
+++ b/src/main/java/de/cuioss/tools/string/Splitter.java
@@ -280,9 +280,11 @@ public final class Splitter {
      *                                                regular expression
      */
     public Splitter doNotModifySeparatorString() {
+        // Preserve the flags of a Pattern supplied via on(Pattern)
+        var existingFlags = null != splitterConfig.getPattern() ? splitterConfig.getPattern().flags() : 0;
         var newConfig = splitterConfig.copy()
                 .doNotModifySeparatorString(true)
-                .pattern(Pattern.compile(splitterConfig.getSeparator()))
+                .pattern(Pattern.compile(splitterConfig.getSeparator(), existingFlags))
                 .build();
         return new Splitter(newConfig);
     }

--- a/src/main/java/de/cuioss/tools/string/Splitter.java
+++ b/src/main/java/de/cuioss/tools/string/Splitter.java
@@ -60,6 +60,17 @@ import static de.cuioss.tools.string.MoreStrings.isEmpty;
  *     .splitToList("a,,c");
  * // result = ["a", "c"]
  * </pre>
+ * <p>
+ * Note: Following {@link String#split(String)} semantics, <em>trailing</em> empty
+ * strings are always removed from the result, whereas <em>leading</em> and inner
+ * empty strings are kept (unless {@link #omitEmptyStrings()} is used):
+ * </p>
+ * <pre>
+ * Splitter.on(',').splitToList(",a,,")  = ["", "a"]   // leading kept, trailing removed
+ * </pre>
+ * <p>
+ * This differs from Guava's Splitter, which keeps trailing empty strings by default.
+ * </p>
  *
  * <h3>3. Trimming Results</h3>
  * <pre>
@@ -87,6 +98,8 @@ import static de.cuioss.tools.string.MoreStrings.isEmpty;
  *       <li>Guava applies trim/omit first, then limit</li>
  *     </ul>
  *   </li>
+ *   <li>Note that trailing empty strings are always removed from the result
+ *   ({@link String#split(String)} semantics), while Guava keeps them by default</li>
  * </ol>
  *
  * @author Oliver Wolff
@@ -247,24 +260,29 @@ public final class Splitter {
     }
 
     /**
-     * Configures this splitter to use the separator string as a literal pattern without escaping special regex characters.
-     * This is useful when you want to split on a regular expression pattern.
+     * Configures this splitter to treat the separator string as a raw regular
+     * expression instead of quoting it. By default, separators given to
+     * {@link #on(String)} are treated as literal strings; with this option the
+     * separator is compiled as a regular expression as-is.
      *
      * <pre>
-     * Without doNotModifySeparatorString()
-     * Splitter.on("[").splitToList("[a][b]")      // Throws IllegalArgumentException
+     * // Without doNotModifySeparatorString(): separator is treated literally
+     * Splitter.on("[,.]").splitToList("a[,.]b")                             = ["a", "b"]
+     * Splitter.on("[,.]").splitToList("a,b.c")                              = ["a,b.c"]
      *
-     * With doNotModifySeparatorString()
-     * Splitter.on("[").doNotModifySeparatorString().splitToList("[a][b]")  = ["", "a", "[b]"]
+     * // With doNotModifySeparatorString(): separator is treated as a regex
+     * Splitter.on("[,.]").doNotModifySeparatorString().splitToList("a,b.c") = ["a", "b", "c"]
      * </pre>
      *
-     * @return a new {@link Splitter} instance with the same configuration but with doNotModifySeparatorString set to true
+     * @return a new {@link Splitter} instance with the same configuration but with the
+     * separator compiled as a raw regular expression
+     * @throws java.util.regex.PatternSyntaxException if the separator is not a valid
+     *                                                regular expression
      */
     public Splitter doNotModifySeparatorString() {
-        var separator = splitterConfig.getSeparator();
         var newConfig = splitterConfig.copy()
                 .doNotModifySeparatorString(true)
-                .pattern(Pattern.compile(Pattern.quote(separator)))
+                .pattern(Pattern.compile(splitterConfig.getSeparator()))
                 .build();
         return new Splitter(newConfig);
     }
@@ -272,6 +290,15 @@ public final class Splitter {
     /**
      * Splits {@code sequence} into string components and returns them as an
      * immutable list.
+     * <p>
+     * Note: Following {@link String#split(String)} limit-0 semantics,
+     * <em>trailing</em> empty strings are always removed from the result, whereas
+     * <em>leading</em> and inner empty strings are kept (unless
+     * {@link #omitEmptyStrings()} is configured). This differs from Guava:
+     * </p>
+     * <pre>
+     * Splitter.on(',').splitToList(",a,,")  = ["", "a"]
+     * </pre>
      *
      * @param sequence the sequence of characters to split
      *
@@ -295,10 +322,12 @@ public final class Splitter {
 
         var pattern = splitterConfig.getPattern();
         if (pattern == null) {
-            pattern = Pattern.compile(Pattern.quote(splitterConfig.getSeparator()));
+            pattern = splitterConfig.isDoNotModifySeparatorString()
+                    ? Pattern.compile(splitterConfig.getSeparator())
+                    : Pattern.compile(Pattern.quote(splitterConfig.getSeparator()));
         }
 
-        var splitted = sequence.split(pattern.pattern(), splitterConfig.getMaxItems());
+        var splitted = pattern.split(sequence, splitterConfig.getMaxItems());
         if (0 == splitted.length) {
             LOGGER.trace("No content to be returned for input %s and configuration %s", sequence, splitterConfig);
             return Collections.emptyList();

--- a/src/main/java/de/cuioss/tools/string/SplitterConfig.java
+++ b/src/main/java/de/cuioss/tools/string/SplitterConfig.java
@@ -38,23 +38,24 @@ import java.util.regex.Pattern;
  *
  * <h2>Usage Examples</h2>
  * <pre>
- * // Basic configuration
+ * // Basic configuration: without an explicit pattern the separator is
+ * // treated as a literal string
  * SplitterConfig config1 = SplitterConfig.builder()
  *     .separator(",")
  *     .build();
  *
  * // Advanced configuration
  * SplitterConfig config2 = SplitterConfig.builder()
- *     .separator("\\s*,\\s*")  // Split on comma with optional whitespace
+ *     .separator(",")
  *     .omitEmptyStrings(true)
  *     .trimResults(true)
  *     .maxItems(3)             // Limit to 3 splits
  *     .build();
  *
- * // Raw separator configuration
+ * // Regex separator configuration
  * SplitterConfig config3 = SplitterConfig.builder()
- *     .separator("[,.]")       // Split on comma or period
- *     .doNotModifySeparatorString(true)  // Use separator as-is
+ *     .separator("[,.]")                 // Split on comma or period
+ *     .doNotModifySeparatorString(true)  // Treat separator as a raw regex
  *     .build();
  * </pre>
  *

--- a/src/main/java/de/cuioss/tools/string/TextSplitter.java
+++ b/src/main/java/de/cuioss/tools/string/TextSplitter.java
@@ -15,6 +15,7 @@
  */
 package de.cuioss.tools.string;
 
+import de.cuioss.tools.base.Preconditions;
 import de.cuioss.tools.collect.MapBuilder;
 import lombok.EqualsAndHashCode;
 import lombok.Setter;
@@ -141,10 +142,13 @@ public class TextSplitter implements Serializable {
      * Creates a new TextSplitter with custom length settings.
      *
      * @param source text to be processed, will be converted to empty string if null
-     * @param forceLengthBreakCount maximum length before forcing line breaks
-     * @param abridgedLengthCount maximum length before abridging with ellipsis
+     * @param forceLengthBreakCount maximum length before forcing line breaks, must be greater than 0
+     * @param abridgedLengthCount maximum length before abridging with ellipsis, must be greater than 0
+     * @throws IllegalArgumentException if one of the length parameters is not greater than 0
      */
     public TextSplitter(final String source, final int forceLengthBreakCount, final int abridgedLengthCount) {
+        Preconditions.checkArgument(forceLengthBreakCount > 0, "forceLengthBreakCount must be greater than 0");
+        Preconditions.checkArgument(abridgedLengthCount > 0, "abridgedLengthCount must be greater than 0");
         this.source = nullToEmpty(source);
         forceLengthBreak = valueOf(forceLengthBreakCount);
         abridgedLength = valueOf(abridgedLengthCount);
@@ -186,7 +190,7 @@ public class TextSplitter implements Serializable {
      * @return {@code true} if the abridged text is truncated with ellipsis
      */
     public boolean isAbridged() {
-        return getAbridgedText().endsWith(TRADE_STR);
+        return source.length() > getAbridgedLength() && getAbridgedText().endsWith(TRADE_STR);
     }
 
     /**

--- a/src/main/java/de/cuioss/tools/string/TextSplitter.java
+++ b/src/main/java/de/cuioss/tools/string/TextSplitter.java
@@ -17,7 +17,6 @@ package de.cuioss.tools.string;
 
 import de.cuioss.tools.collect.MapBuilder;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
@@ -45,22 +44,28 @@ import static java.lang.Integer.valueOf;
  *
  * <h2>Key Features</h2>
  * <ul>
- *   <li>Immutable value object design</li>
- *   <li>Configurable length limits for abridging and line breaks</li>
+ *   <li>Configurable length limits for abridging and line breaks, adjustable via setters</li>
  *   <li>Smart handling of punctuation for line breaks</li>
  *   <li>Preservation of existing word boundaries</li>
  * </ul>
+ * <p>
+ * The derived values are computed on demand: every call of {@link #getAbridgedText()},
+ * {@link #getTextWithEnforcedLineBreaks()} or {@link #isAbridged()} reflects the
+ * currently configured length settings.
+ * </p>
  *
  * <h2>Usage Examples</h2>
  * <pre>
  * // Basic usage with defaults
  * TextSplitter splitter1 = new TextSplitter("This is a very long text that needs splitting");
- * String abridged = splitter1.getAbridgedText();          // "This is a very lon..."
+ * String abridged = splitter1.getAbridgedText();          // "This is a very ..."
  * String withBreaks = splitter1.getTextWithEnforcedLineBreaks();  // Adds zero-width spaces
  *
  * // Custom configuration
  * TextSplitter splitter2 = new TextSplitter("Long.Technical-ID#12345", 5, 10);
- * // Results in: "Long.⁠Technical-⁠ID#⁠12345" (⁠ represents zero-width space)
+ * splitter2.getTextWithEnforcedLineBreaks();
+ * // Results in "Long." + ZWSP + "Techn" + ZWSP + "ical-" + ZWSP + "ID#" + ZWSP + "12345"
+ * // (ZWSP represents the zero-width space character U+200B)
  * </pre>
  *
  * @author Eugen Fischer
@@ -110,27 +115,6 @@ public class TextSplitter implements Serializable {
     private final String source;
 
     /**
-     * Lazily initialized abridged version of the source text.
-     * Will be truncated with ellipsis if longer than the configured length.
-     */
-    @Getter(lazy = true)
-    private final String abridgedText = initAbridged();
-
-    /**
-     * Indicates whether the text was actually abridged.
-     * True if the text ends with ellipsis, false otherwise.
-     */
-    @Getter
-    private boolean abridged = false;
-
-    /**
-     * Lazily initialized version of the text with enforced line breaks.
-     * Contains zero-width spaces at appropriate break points.
-     */
-    @Getter(lazy = true)
-    private final String textWithEnforcedLineBreaks = initTextWithLineBreaks();
-
-    /**
      * Maximum length of text segments before forcing a line break.
      * If null, uses {@link #DEFAULT_FORCE_LENGTH_BREAK}.
      */
@@ -156,12 +140,12 @@ public class TextSplitter implements Serializable {
     /**
      * Creates a new TextSplitter with custom length settings.
      *
-     * @param source text to be processed
+     * @param source text to be processed, will be converted to empty string if null
      * @param forceLengthBreakCount maximum length before forcing line breaks
      * @param abridgedLengthCount maximum length before abridging with ellipsis
      */
     public TextSplitter(final String source, final int forceLengthBreakCount, final int abridgedLengthCount) {
-        this.source = source;
+        this.source = nullToEmpty(source);
         forceLengthBreak = valueOf(forceLengthBreakCount);
         abridgedLength = valueOf(abridgedLengthCount);
     }
@@ -174,7 +158,14 @@ public class TextSplitter implements Serializable {
         return abridgedLength != null ? abridgedLength : DEFAULT_ABRIDGED_LENGTH;
     }
 
-    private String initAbridged() {
+    /**
+     * Returns the abridged version of the source text, truncated with ellipsis if
+     * longer than the configured length. The value is computed on each call,
+     * reflecting the currently configured {@code abridgedLength}.
+     *
+     * @return the abridged text
+     */
+    public String getAbridgedText() {
         String result = "";
 
         if (!isEmpty(source)) {
@@ -184,12 +175,18 @@ public class TextSplitter implements Serializable {
                     : abridgeHumanProducedText(sourceSplitted);
         }
 
-        abridged = endsWith(result, TRADE_STR);
         return result.trim();
     }
 
-    private static boolean endsWith(final String str, final String suffix) {
-        return str.trim().endsWith(suffix);
+    /**
+     * Indicates whether the text gets abridged with the currently configured
+     * {@code abridgedLength}. The value is computed on each call and does not
+     * depend on {@link #getAbridgedText()} having been called before.
+     *
+     * @return {@code true} if the abridged text is truncated with ellipsis
+     */
+    public boolean isAbridged() {
+        return getAbridgedText().endsWith(TRADE_STR);
     }
 
     /**
@@ -229,7 +226,14 @@ public class TextSplitter implements Serializable {
         return builder.toString();
     }
 
-    private String initTextWithLineBreaks() {
+    /**
+     * Returns the source text with enforced line break opportunities, containing
+     * zero-width spaces at appropriate break points. The value is computed on each
+     * call, reflecting the currently configured {@code forceLengthBreak}.
+     *
+     * @return the text with enforced line breaks
+     */
+    public String getTextWithEnforcedLineBreaks() {
         if (isEmpty(source)) {
             return "";
         }

--- a/src/main/java/de/cuioss/tools/string/package-info.java
+++ b/src/main/java/de/cuioss/tools/string/package-info.java
@@ -29,7 +29,7 @@
  *     <ul>
  *       <li>{@link de.cuioss.tools.string.MoreStrings} - Enhanced string utilities</li>
  *       <li>Null-safe string operations</li>
- *       <li>String formatting with '%s' and '{}' placeholders</li>
+ *       <li>Lenient string formatting with '%s' placeholders</li>
  *       <li>Common string transformations</li>
  *     </ul>
  *   </li>
@@ -61,7 +61,7 @@
  * // Null-safe operations
  * String nullString = null;
  * String empty = MoreStrings.nullToEmpty(nullString);      // Returns ""
- * String defaulted = MoreStrings.nullToDefault(nullString, "N/A");  // Returns "N/A"
+ * String defaulted = MoreStrings.firstNonEmpty(nullString, "N/A").orElse("");  // Returns "N/A"
  *
  * // String formatting with logging
  * try {
@@ -83,9 +83,8 @@
  *
  * // Advanced joining with configuration
  * String result = Joiner.on(" | ")
- *     .skipNulls()           // Skip null values
- *     .skipEmpty()           // Skip empty strings
  *     .useForNull("N/A")     // Replace nulls with "N/A"
+ *     .skipEmptyStrings()    // Skip empty strings
  *     .join(Arrays.asList("a", null, "", "b"));  // "a | N/A | b"
  * </pre>
  *

--- a/src/test/java/de/cuioss/tools/formatting/template/TemplateFormatterTest.java
+++ b/src/test/java/de/cuioss/tools/formatting/template/TemplateFormatterTest.java
@@ -206,6 +206,16 @@ class TemplateFormatterTest {
     }
 
     @Test
+    void shouldEmitTrailingStaticTextWhenEarlierAttributeHasValue() {
+        final var personName = PersonName.builder().familyName("FamilyName").build();
+
+        final TemplateFormatter<PersonName> formatter = TemplateFormatterImpl
+                .createFormatter("[familyName] [middleName] Suffix", PersonName.class);
+
+        assertEquals("FamilyName Suffix", formatter.format(personName));
+    }
+
+    @Test
     void shouldSuppressStaticTextForMissingAttribute() {
         final var personName = PersonName.builder().givenName("GivenName").build();
 

--- a/src/test/java/de/cuioss/tools/formatting/template/TemplateFormatterTest.java
+++ b/src/test/java/de/cuioss/tools/formatting/template/TemplateFormatterTest.java
@@ -175,17 +175,44 @@ class TemplateFormatterTest {
         assertEquals(expected, formatter.format(object1));
     }
 
-    /**
-     * Test Idea : Separator should be added if both token are available: -
-     * [[token1], [token2]] than VALUE1, VALUE2 are displayed - if token 2 is
-     * missing no separator will be added : VALUE1 - if token 1 is missing no
-     * separator will be added : VALUE2
-     */
-    void shouldProvideConditionalFormatting() {
-        /*
-         * implementation idea : use Guava JOINER for String Tokens in between therefore
-         * tree graph is needed, no linear list is able to represent this
-         */
+    @Test
+    void shouldFormatTemplateWithStaticPrefix() {
+        final var personName = PersonName.builder().familyName("FamilyName").givenName("GivenName").build();
+
+        final TemplateFormatter<PersonName> formatter = TemplateFormatterImpl.createFormatter("Name: [familyName]",
+                PersonName.class);
+
+        assertEquals("Name: FamilyName", formatter.format(personName));
+    }
+
+    @Test
+    void shouldFormatTemplateWithStaticSuffix() {
+        final var personName = PersonName.builder().familyName("FamilyName").givenName("GivenName").build();
+
+        final TemplateFormatter<PersonName> formatter = TemplateFormatterImpl
+                .createFormatter("[familyName] is the family name", PersonName.class);
+
+        assertEquals("FamilyName is the family name", formatter.format(personName));
+    }
+
+    @Test
+    void shouldFormatTemplateWithStaticPrefixAndSuffix() {
+        final var personName = PersonName.builder().familyName("FamilyName").givenName("GivenName").build();
+
+        final TemplateFormatter<PersonName> formatter = TemplateFormatterImpl
+                .createFormatter("Prefix: [familyName] Suffix", PersonName.class);
+
+        assertEquals("Prefix: FamilyName Suffix", formatter.format(personName));
+    }
+
+    @Test
+    void shouldSuppressStaticTextForMissingAttribute() {
+        final var personName = PersonName.builder().givenName("GivenName").build();
+
+        final TemplateFormatter<PersonName> formatter = TemplateFormatterImpl
+                .createFormatter("Prefix: [familyName] Suffix", PersonName.class);
+
+        assertEquals("", formatter.format(personName));
     }
 
     /* HELPER METHODS AND CLASSES */

--- a/src/test/java/de/cuioss/tools/formatting/template/TemplateManagerTest.java
+++ b/src/test/java/de/cuioss/tools/formatting/template/TemplateManagerTest.java
@@ -38,22 +38,22 @@ class TemplateManagerTest {
         actual = manager.format(targetToFormat, Locale.GERMANY);
 
         // expected result givenName, familyName
-        assertEquals("Hans, M\00FCller", actual);
+        assertEquals("Hans, Müller", actual);
 
         final var resultUS = manager.format(targetToFormat, Locale.US);
         // expected result familyName, givenName
-        assertEquals("M\00FCller, Hans", resultUS);
+        assertEquals("Müller, Hans", resultUS);
 
         // expect fallback to default formatter
         final var resultDefault = manager.format(targetToFormat, Locale.CHINA);
         // expected result familyName
-        assertEquals("M\00FCller", resultDefault);
+        assertEquals("Müller", resultDefault);
 
     }
 
     private static PersonName anyPersonName() {
         final var person = new PersonName();
-        person.setFamilyName("M\00FCller");
+        person.setFamilyName("Müller");
         person.setGivenName("Hans");
         return person;
     }
@@ -86,7 +86,7 @@ class TemplateManagerTest {
         targetToFormat = anyPersonName();
         actual = manager.format(targetToFormat, Locale.FRENCH);
 
-        assertNotEquals("Hans, M\00FCller", actual);
+        assertNotEquals("Hans, Müller", actual);
     }
 
     @Test
@@ -102,7 +102,7 @@ class TemplateManagerTest {
         manager = templateManagerWithoutLocation();
         targetToFormat = anyPersonName();
         actual = manager.format(targetToFormat, Locale.GERMANY);
-        assertNotEquals("Hans, M\00FCller", actual);
+        assertNotEquals("Hans, Müller", actual);
     }
 
     @Test
@@ -110,7 +110,7 @@ class TemplateManagerTest {
         manager = templateManagerWithoutOneLocation();
         targetToFormat = anyPersonName();
         actual = manager.format(targetToFormat, Locale.GERMANY);
-        assertEquals("Hans, M\00FCller", actual);
+        assertEquals("Hans, Müller", actual);
     }
 
     @Test
@@ -118,7 +118,7 @@ class TemplateManagerTest {
         manager = templateManagerWithoutLocation2();
         targetToFormat = anyPersonName();
         actual = manager.format(targetToFormat, Locale.GERMANY);
-        assertNotEquals("Hans, M\00FCller", actual);
+        assertNotEquals("Hans, Müller", actual);
     }
 
     private static TemplateManager<PersonName> templateManagerWithoutLocation() {

--- a/src/test/java/de/cuioss/tools/formatting/template/lexer/BracketLexerTest.java
+++ b/src/test/java/de/cuioss/tools/formatting/template/lexer/BracketLexerTest.java
@@ -74,6 +74,16 @@ class BracketLexerTest {
     }
 
     @Test
+    void shouldPassValidationWithStaticPrefixOnly() {
+        Validator.validateTemplate("StaticPrefix: [familyName]", PersonName.class);
+    }
+
+    @Test
+    void shouldPassValidationWithStaticSuffixOnly() {
+        Validator.validateTemplate("[familyName] StaticSuffix", PersonName.class);
+    }
+
+    @Test
     void shouldPassValidationForAngleBrackets() {
         Validator.validateTemplate(PERSON_NAME_FORMAT_ANGLE_BRACKET,
                 LexerBuilder.withExpressionLanguage(ExpressionLanguage.SIMPLE_ANGLE_BRACKET).build(PersonName.class));

--- a/src/test/java/de/cuioss/tools/formatting/template/token/ActionTokenTest.java
+++ b/src/test/java/de/cuioss/tools/formatting/template/token/ActionTokenTest.java
@@ -17,8 +17,17 @@ package de.cuioss.tools.formatting.template.token;
 
 import de.cuioss.test.generator.Generators;
 import de.cuioss.test.generator.junit.EnableGeneratorController;
+import de.cuioss.tools.formatting.template.FormatterSupport;
 import de.cuioss.tools.support.ObjectMethodsAsserts;
 import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @EnableGeneratorController
 class ActionTokenTest {
@@ -29,6 +38,39 @@ class ActionTokenTest {
         var token = Generators.letterStrings(5, 10).next();
         var template = "prefix" + token + "suffix";
         ObjectMethodsAsserts.assertNiceObject(new ActionToken(template, token));
+    }
+
+    @Test
+    void shouldTreatAttributeNameAsLiteralNotAsRegex() {
+        // '[a+b]' as a regex would be a character class, as a literal it is the attribute name
+        var actionToken = new ActionToken("<[a+b]>", "[a+b]");
+        assertEquals("<value>", actionToken.substituteAttribute(new MapBasedFormatterSupport("[a+b]", "value")));
+    }
+
+    @Test
+    void shouldFailOnTemplateNotContainingToken() {
+        assertThrows(IllegalArgumentException.class, () -> new ActionToken("someTemplate", "missing"));
+    }
+
+    private static class MapBasedFormatterSupport implements FormatterSupport {
+
+        private final Map<String, Serializable> values = new HashMap<>();
+
+        MapBasedFormatterSupport(final String attribute, final String value) {
+            values.put(attribute, value);
+            // second value in order to bypass the single-value special case
+            values.put("other", "otherValue");
+        }
+
+        @Override
+        public Map<String, Serializable> getAvailablePropertyValues() {
+            return values;
+        }
+
+        @Override
+        public List<String> getSupportedPropertyNames() {
+            return List.copyOf(values.keySet());
+        }
     }
 
 }

--- a/src/test/java/de/cuioss/tools/string/MoreStringsTest.java
+++ b/src/test/java/de/cuioss/tools/string/MoreStringsTest.java
@@ -61,6 +61,15 @@ class MoreStringsTest {
         }
     }
 
+    @Test
+    void shouldUnquoteSingleCharacterStrings() {
+        assertEquals("'", unquote("'"));
+        assertEquals("\"", unquote("\""));
+        assertEquals("a", unquote("a"));
+        assertEquals("", unquote("''"));
+        assertEquals("", unquote("\"\""));
+    }
+
     /**
      * Test for {@link MoreStrings#isAllLowerCase(CharSequence)}. COPIED FROM:
      * <a href="https://github.com/apache/commons-lang/blob/LANG_3_8_1/src/test/java/org/apache/commons/lang3/MoreStringsTest.java">...</a>
@@ -557,6 +566,9 @@ class MoreStringsTest {
         // Test normal behavior with valid checker
         assertEquals("test",
                 MoreStrings.coalesce(MoreStrings::isEmpty, "", null, "test", "other").orElseThrow());
+
+        // A non-rejected null value results in Optional.empty() instead of an NPE
+        assertTrue(MoreStrings.coalesce(value -> false, (String) null).isEmpty());
     }
 
     private static class ThrowsOnToString {

--- a/src/test/java/de/cuioss/tools/string/SplitterTest.java
+++ b/src/test/java/de/cuioss/tools/string/SplitterTest.java
@@ -18,6 +18,8 @@ package de.cuioss.tools.string;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import static de.cuioss.tools.collect.CollectionLiterals.immutableList;
 import static org.junit.jupiter.api.Assertions.*;
@@ -252,32 +254,39 @@ class SplitterTest {
             var splitted = Splitter.on(special).splitToList(template);
             assertEquals(elements, splitted);
         }
-
-        var splitter = Splitter.on("[").doNotModifySeparatorString();
-        var result = splitter.splitToList("[boom]");
-        assertEquals(immutableList("", "boom]"), result);
     }
 
     @Test
-    void doNotModifySeparatorStringWithAllRegexMetacharacters() {
-        // Test all regex metacharacters work as literal separators when using doNotModifySeparatorString
-        String[] regexMetacharacters = {"[", "]", "{", "}", "(", ")", "*", "+", "?", "^", "$", "|", "\\", "."};
+    void doNotModifySeparatorStringShouldTreatSeparatorAsRegex() {
+        // With the flag: the separator is used as a raw regex, splitting on ',' and '.'
+        var result = Splitter.on("[,.]").doNotModifySeparatorString().splitToList("a,b.c");
+        assertEquals(immutableList("a", "b", "c"), result);
+    }
 
-        for (String metachar : regexMetacharacters) {
-            var splitter = Splitter.on(metachar).doNotModifySeparatorString();
-            var result = splitter.splitToList("test" + metachar + "data");
-            assertEquals(immutableList("test", "data"), result,
-                    "Regex metacharacter should work as literal separator: " + metachar);
-        }
+    @Test
+    void separatorShouldBeTreatedLiterallyWithoutDoNotModifySeparatorString() {
+        // Without the flag: the separator is the literal string "[,.]"
+        assertEquals(immutableList("a", "b"), Splitter.on("[,.]").splitToList("a[,.]b"));
+        assertEquals(immutableList("a,b.c"), Splitter.on("[,.]").splitToList("a,b.c"));
+    }
 
-        // Test that normal characters work fine
-        String[] normalSeparators = {",", ";", ":", "-", "_", "@", "#", "~"};
-        for (String separator : normalSeparators) {
-            var splitter = Splitter.on(separator).doNotModifySeparatorString();
-            var result = splitter.splitToList("test" + separator + "data");
-            assertEquals(immutableList("test", "data"), result,
-                    "Normal separator should work: " + separator);
-        }
+    @Test
+    void doNotModifySeparatorStringShouldFailOnInvalidRegex() {
+        var splitter = Splitter.on("[");
+        assertThrows(PatternSyntaxException.class, splitter::doNotModifySeparatorString);
+    }
+
+    @Test
+    void shouldHonorFlagsOfUserSuppliedPattern() {
+        var pattern = Pattern.compile("a", Pattern.CASE_INSENSITIVE);
+        var result = Splitter.on(pattern).splitToList("xAy");
+        assertEquals(immutableList("x", "y"), result);
+    }
+
+    @Test
+    void shouldKeepLeadingButRemoveTrailingEmptyStrings() {
+        // String#split limit-0 semantics: trailing empty strings are removed, leading kept
+        assertEquals(immutableList("", "a"), COMMA_SPLITTER.splitToList(",a,,"));
     }
 
     @Test

--- a/src/test/java/de/cuioss/tools/string/TextSplitterTest.java
+++ b/src/test/java/de/cuioss/tools/string/TextSplitterTest.java
@@ -97,6 +97,39 @@ class TextSplitterTest {
     }
 
     @Test
+    void shouldComputeAbridgedStateWithoutPriorGetterCall() {
+        textSplitter = new TextSplitter("Myextremlylongtextwithsomeusefullinformation");
+        textSplitter.setAbridgedLength(valueOf(16));
+
+        // isAbridged() must not depend on getAbridgedText() having been called before
+        assertTrue(textSplitter.isAbridged());
+    }
+
+    @Test
+    void shouldHonorSetterCalledAfterGetterCall() {
+        final var text = "Myextremlylongtextwithsomeusefullinformation";
+        textSplitter = new TextSplitter(text);
+        textSplitter.setAbridgedLength(valueOf(16));
+
+        assertEquals("Myextremlylo ...", textSplitter.getAbridgedText(), ABRIDGED_TEXT_IS_WRONG);
+        assertTrue(textSplitter.isAbridged());
+
+        // Setter after the first get must affect subsequent computations
+        textSplitter.setAbridgedLength(valueOf(50));
+        assertEquals(text, textSplitter.getAbridgedText(), ABRIDGED_TEXT_IS_WRONG);
+        assertFalse(textSplitter.isAbridged());
+    }
+
+    @Test
+    void shouldHandleNullSourceInThreeArgConstructor() {
+        textSplitter = new TextSplitter(null, 5, 10);
+
+        assertEquals("", textSplitter.getAbridgedText(), ABRIDGED_TEXT_IS_WRONG);
+        assertEquals("", textSplitter.getTextWithEnforcedLineBreaks(), TEXT_WITH_ENFORCED_LINEBREAKS_IS_WRONG);
+        assertFalse(textSplitter.isAbridged());
+    }
+
+    @Test
     void shouldProvideTextRepresentationForComputerCreatedTextSequence() {
         final var text = "shouldProvideTextRepresentationForComputerCreatedTextSequence";
         textSplitter = new TextSplitter(text);

--- a/src/test/java/de/cuioss/tools/string/TextSplitterTest.java
+++ b/src/test/java/de/cuioss/tools/string/TextSplitterTest.java
@@ -22,6 +22,21 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class TextSplitterTest {
 
+    @Test
+    void shouldRejectNonPositiveLengthSettings() {
+        assertThrows(IllegalArgumentException.class, () -> new TextSplitter("text", 0, 10));
+        assertThrows(IllegalArgumentException.class, () -> new TextSplitter("text", 10, 0));
+        assertThrows(IllegalArgumentException.class, () -> new TextSplitter("text", -1, -1));
+    }
+
+    @Test
+    void shouldNotReportAbridgedForShortSourceEndingWithEllipsis() {
+        var splitter = new TextSplitter("short ...");
+        assertEquals("short ...", splitter.getAbridgedText());
+        assertFalse(splitter.isAbridged(),
+                "A source that naturally ends with '...' but was never truncated must not report abridged");
+    }
+
     private static final String TEXT_WITH_ENFORCED_LINEBREAKS_IS_WRONG = "Text with enforced linebreaks is wrong.";
 
     private static final String ABRIDGED_TEXT_IS_WRONG = "Abridged text is wrong.";


### PR DESCRIPTION
## Summary

Cluster D of the project-analysis fix series (findings catalog: `doc/analysis-findings.md`, IDs FMT-1..FMT-8, STR-1..STR-11).

**Template formatting (two high-severity bugs, verified at runtime):**
- **FMT-1 (high)**: `BracketLexer` falsely rejected balanced templates with static text on exactly one side (`"StaticPrefix: [familyName]"` → "unbalanced" `IllegalArgumentException`) because it compared splitter chunk counts and `Splitter` drops trailing empty segments. Now counts `[`/`]` directly.
- **FMT-2 (high)**: `TemplateFormatterImpl.format()` silently dropped leading and trailing static text (`"Prefix: [familyName] Suffix"` → `"Family"`). Literal text now appears as-is when the adjacent attribute yields a value; separator suppression between attributes is unchanged, and all pre-existing formatter tests pass unchanged.
- **FMT-3**: `ActionToken` treated attribute names as regex (`template.split(token)`) — metacharacters broke or threw `PatternSyntaxException`; now index-based.
- **FMT-4**: `SimpleFormatter`'s value filter silently hit the varargs `MoreCollections.isEmpty(Object...)` overload (always false — dead filter); now uses `MoreStrings.isEmpty`.
- **FMT-5**: removed `ExpressionLanguage.STEL` — `LexerBuilder` throws for it, so no caller can ever have used it; the `SIMPLE_SQUARED_BRACKTES` typo constant stays (renaming would break API) with a javadoc note.
- **FMT-6/FMT-7**: replaced fabricated javadoc examples (nonexistent `LexerBuilder.create()`, `tokenize()`, one-arg `ActionToken`, placeholder blocks) with real, compiling API usage; rewrote the garbled `Validator.validate` doc.
- **FMT-8 (tests)**: deleted an empty `@Test`-less method; added prefix/suffix/both/suppression formatting tests and lexer validation tests; fixed eight `"M\00FCller"` literals (octal NUL escape, `ü` intended) in `TemplateManagerTest`.

**Strings:**
- **STR-1**: `unquote("'")` crashed with `StringIndexOutOfBoundsException`; now returns the input for length < 2.
- **STR-2**: `Splitter.on(Pattern)` recompiled the pattern from source, silently discarding flags like `CASE_INSENSITIVE`; now uses `pattern.split(...)`.
- **STR-3**: `doNotModifySeparatorString()` was a documented-as-regex no-op (flag never read; separator always quoted). It now genuinely compiles the separator as a raw regex; docs and `SplitterConfig` examples corrected. Two tests that pinned the old no-op behavior were replaced accordingly.
- **STR-4**: documented the previously-undocumented asymmetry that trailing empty segments are always removed while leading ones are kept (`String.split` limit-0 semantics; divergence from Guava), pinned by test.
- **STR-5**: `coalesce` javadoc described the exact opposite of the implementation (the predicate *rejects* values); doc fixed and non-rejected null now yields `Optional.empty()` instead of NPE.
- **STR-6..STR-8**: package/method examples fixed (nonexistent `nullToDefault`/`skipEmpty()`, impossible example output, wrong method labels, `countMatches("banana","a")` is 3 not 2, malformed `</pre>`).
- **STR-9**: removed a leftover debug statement in `lenientFormat` that logged a factually wrong FINE message on **every** invocation — the hot path of every parameterized `CuiLogger` call.
- **STR-10**: removed unreachable `requireNonNull` calls behind Lombok `@NonNull`.
- **STR-11**: `TextSplitter` claimed immutability but had setters plus lazily-cached derived values — `isAbridged()` returned false until `getAbridgedText()` happened to be called, and setters were silently ignored after the first get. Derived values are now computed on demand; constructors handle null consistently; class examples corrected.

## Test plan

- `./mvnw clean install` — BUILD SUCCESS, 812 tests, 0 failures/errors (full suite, including io/collect/net tests that depend on Splitter semantics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKzn4Upj33uRFvWQep3UzE

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKzn4Upj33uRFvWQep3UzE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved template formatting so static text around placeholders is handled more naturally in more cases.

* **Bug Fixes**
  * Fixed string joining, splitting, and quoting edge cases, including empty values, single-character quotes, and null handling.
  * Improved template and token processing so placeholders and separators are treated more consistently.
  * Updated text abbreviation behavior to reflect current settings reliably.

* **Documentation**
  * Expanded usage examples and clarified formatting, splitting, and validation behavior in the public docs.

* **Refactor**
  * Simplified internal validation and parsing logic for better consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->