### PR TITLE
io: fix stream reentrancy, path handling and temp-file suffix bugs

### DIFF
--- a/src/main/java/de/cuioss/tools/io/ClassPathLoader.java
+++ b/src/main/java/de/cuioss/tools/io/ClassPathLoader.java
@@ -136,7 +136,10 @@ public class ClassPathLoader implements FileLoader {
         }
         var loader = Optional.ofNullable(Thread.currentThread().getContextClassLoader());
         if (loader.isPresent()) {
-            url = loader.get().getResource(path);
+            // In contrast to Class#getResource, ClassLoader#getResource expects the name
+            // without a leading slash
+            var classLoaderPath = path.startsWith("/") ? path.substring(1) : path;
+            url = loader.get().getResource(classLoaderPath);
             if (null != url) {
                 LOGGER.debug("Resolved '%s' from ContextClassLoader", path);
                 return url;

--- a/src/main/java/de/cuioss/tools/io/FileLoaderUtility.java
+++ b/src/main/java/de/cuioss/tools/io/FileLoaderUtility.java
@@ -96,7 +96,7 @@ public final class FileLoaderUtility {
 
         // Create temp file with secure permissions (owner read/write only)
         // This addresses SonarQube security warning about publicly writable directories
-        final Path target = PathTraversalSecurity.createSecureTempFile(namePart, suffix);
+        final Path target = PathTraversalSecurity.createSecureTempFile(namePart, null != suffix ? "." + suffix : null);
 
         try (final var inputStream = source.inputStream()) {
             Files.copy(new BufferedInputStream(inputStream), target, StandardCopyOption.REPLACE_EXISTING);

--- a/src/main/java/de/cuioss/tools/io/FileSystemLoader.java
+++ b/src/main/java/de/cuioss/tools/io/FileSystemLoader.java
@@ -125,6 +125,9 @@ public class FileSystemLoader implements FileReaderWriter {
             newPathName = FileTypePrefix.FILE.removePrefix(pathName);
         } else if (pathName.startsWith(FileTypePrefix.EXTERNAL.getPrefix())) {
             var remainder = FileTypePrefix.EXTERNAL.removePrefix(pathName);
+            if (isEmpty(remainder)) {
+                throw new IllegalArgumentException("Filename " + pathName + " is invalid");
+            }
             try {
                 var currentDir = new File(".").getCanonicalPath();
                 if (!remainder.startsWith("/") && !remainder.startsWith(File.separator)) {

--- a/src/main/java/de/cuioss/tools/io/FileSystemLoader.java
+++ b/src/main/java/de/cuioss/tools/io/FileSystemLoader.java
@@ -64,10 +64,11 @@ public class FileSystemLoader implements FileReaderWriter {
 
     /**
      * @param pathName must not be null nor empty, must not start with the prefix
-     *                 "classpath:" but may start with the prefix "file:" and
-     *                 contain at least one character despite the prefix. On all
-     *                 other cases a {@link IllegalArgumentException} will be
-     *                 thrown.
+     *                 "classpath:" but may start with the prefix "file:" or
+     *                 "external:" and contain at least one character despite the
+     *                 prefix. Paths prefixed with "external:" are resolved
+     *                 relative to the current working directory. On all other
+     *                 cases a {@link IllegalArgumentException} will be thrown.
      */
     public FileSystemLoader(final String pathName) {
         requireNonNull(pathName);
@@ -105,10 +106,11 @@ public class FileSystemLoader implements FileReaderWriter {
      * Checks and modifies a given pathName
      *
      * @param pathName must not be null nor empty, must not start with the prefix
-     *                 "classpath:" but may start with the prefix "file:" and
-     *                 contain at least one character despite the prefix. On all
-     *                 other cases a {@link IllegalArgumentException} will be
-     *                 thrown.
+     *                 "classpath:" but may start with the prefix "file:" or
+     *                 "external:" and contain at least one character despite the
+     *                 prefix. Paths prefixed with "external:" are resolved
+     *                 relative to the current working directory. On all other
+     *                 cases a {@link IllegalArgumentException} will be thrown.
      *
      * @return the normalized pathname without prefix
      */
@@ -122,11 +124,18 @@ public class FileSystemLoader implements FileReaderWriter {
         if (pathName.startsWith(FileTypePrefix.FILE.getPrefix())) {
             newPathName = FileTypePrefix.FILE.removePrefix(pathName);
         } else if (pathName.startsWith(FileTypePrefix.EXTERNAL.getPrefix())) {
+            var remainder = FileTypePrefix.EXTERNAL.removePrefix(pathName);
             try {
-                newPathName = new File(".").getCanonicalPath() + FileTypePrefix.EXTERNAL.removePrefix(pathName);
+                var currentDir = new File(".").getCanonicalPath();
+                if (!remainder.startsWith("/") && !remainder.startsWith(File.separator)) {
+                    remainder = File.separator + remainder;
+                }
+                newPathName = currentDir + remainder;
                 LOGGER.debug("Loading config file from external path: %s", newPathName);
             } catch (final IOException e) {
                 LOGGER.error(e, ERROR.CURRENT_DIR_RETRIEVAL_FAILED);
+                throw new IllegalArgumentException(
+                        "Unable to resolve current working directory for: " + pathName, e);
             }
         }
 
@@ -151,8 +160,11 @@ public class FileSystemLoader implements FileReaderWriter {
     }
 
     /**
-     * Truncate and overwrite an existing file, or create the file if it doesn't
-     * initially exist.
+     * Truncates and overwrites the existing file. The file must exist and be
+     * writable at construction time: {@link #isReadable()} and
+     * {@link #isWritable()} are snapshots taken at construction, and this method
+     * throws an {@link IllegalStateException} if the file was not writable at
+     * that point.
      */
     @Override
     public OutputStream outputStream() throws IOException {

--- a/src/main/java/de/cuioss/tools/io/FileWriter.java
+++ b/src/main/java/de/cuioss/tools/io/FileWriter.java
@@ -40,7 +40,7 @@ public interface FileWriter extends Serializable {
     /**
      * @return an {@link OutputStream} on the corresponding file. It implicitly
      *         checks {@link #isWritable()} before accessing the file and will throw
-     *         an {@link IllegalStateException} in case it is not readable.
+     *         an {@link IllegalStateException} in case it is not writable.
      * @throws IOException
      */
     OutputStream outputStream() throws IOException;

--- a/src/main/java/de/cuioss/tools/io/FilenameUtils.java
+++ b/src/main/java/de/cuioss/tools/io/FilenameUtils.java
@@ -537,7 +537,7 @@ public class FilenameUtils {
      * /foo + /bar          --&gt;   /bar
      * /foo + C:/bar        --&gt;   C:/bar
      * /foo + C:bar         --&gt;   C:bar (*)
-     * /foo/a/ + ../bar     --&gt;   foo/bar
+     * /foo/a/ + ../bar     --&gt;   /foo/bar
      * /foo/ + ../../bar    --&gt;   null
      * /foo/ + /bar         --&gt;   /bar
      * /foo/.. + /bar       --&gt;   /bar

--- a/src/main/java/de/cuioss/tools/io/IOCase.java
+++ b/src/main/java/de/cuioss/tools/io/IOCase.java
@@ -64,7 +64,7 @@ public enum IOCase {
     /**
      * The sensitivity flag.
      */
-    private final transient boolean sensitive;
+    private final boolean sensitive;
 
     // -----------------------------------------------------------------------
 
@@ -96,18 +96,6 @@ public enum IOCase {
         this.name = name;
         this.sensitive = sensitive;
     }
-
-    /**
-     * Replaces the enumeration from the stream with a real one. This ensures that
-     * the correct flag is set for SYSTEM.
-     *
-     * @return the resolved object
-     */
-    Object readResolve() {
-        return forName(name);
-    }
-
-    // -----------------------------------------------------------------------
 
     /**
      * Gets the name of the constant.

--- a/src/main/java/de/cuioss/tools/io/IOStreams.java
+++ b/src/main/java/de/cuioss/tools/io/IOStreams.java
@@ -151,8 +151,8 @@ public class IOStreams {
     }
 
     /**
-     * Gets the contents of an <code>InputStream</code> as a String using the
-     * specified character encoding.
+     * Gets the contents of an <code>InputStream</code> as a String using UTF-8
+     * encoding.
      * <p>
      * This method buffers the input internally, so there is no need to use a
      * <code>BufferedInputStream</code>.
@@ -160,8 +160,8 @@ public class IOStreams {
      *
      * @param input the <code>InputStream</code> to read from, using UTF-8 encoding.
      * @return the requested String
-     * @throws NullPointerException if the input is null
-     * @throws IOException          if an I/O error occurs
+     * @throws IllegalArgumentException if the input is null
+     * @throws IOException              if an I/O error occurs
      */
     public static String toString(final InputStream input) throws IOException {
         return toString(input, StandardCharsets.UTF_8);

--- a/src/main/java/de/cuioss/tools/io/MorePaths.java
+++ b/src/main/java/de/cuioss/tools/io/MorePaths.java
@@ -238,7 +238,12 @@ public final class MorePaths {
      */
     public static Path backupFile(final Path path) throws IOException {
         assertAccessibleFile(path);
-        var backupDir = getBackupDirectoryForPath(path.getParent());
+        var parent = path.getParent();
+        if (null == parent) {
+            // Single-segment relative paths, e.g. Path.of("pom.xml"), have no parent
+            parent = path.toAbsolutePath().getParent();
+        }
+        var backupDir = getBackupDirectoryForPath(parent);
 
         var backupFile = createNonExistingPath(backupDir,
                 path.getFileName() + BACKUP_FILE_SUFFIX + new SimpleDateFormat("yyyyMMddHHmmss").format(new Date()));
@@ -286,7 +291,7 @@ public final class MorePaths {
         PathTraversalSecurity.validatePathSegment(suffix);
 
         // Use secure temp file creation from PathTraversalSecurity to ensure proper permissions
-        var tempFile = PathTraversalSecurity.createSecureTempFile(namePart, suffix);
+        var tempFile = PathTraversalSecurity.createSecureTempFile(namePart, null != suffix ? "." + suffix : null);
 
         Files.copy(realPath, tempFile, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
         LOGGER.debug("Created temp-file from '%s' at '%s'", realPath.toFile().getAbsolutePath(),
@@ -356,11 +361,14 @@ public final class MorePaths {
         try {
             if (file.isDirectory()) {
                 LOGGER.trace("Path %s is directory, checking children", absolutePath);
-                for (String child : file.list()) {
-                    if (!deleteQuietly(path.resolve(child))) {
-                        recursiveSucceful = false;
+                // File#list() may return null on I/O errors, treat as not listable
+                var children = file.list();
+                if (null != children) {
+                    for (String child : children) {
+                        if (!deleteQuietly(path.resolve(child))) {
+                            recursiveSucceful = false;
+                        }
                     }
-
                 }
             }
         } catch (final SecurityException | UnsupportedOperationException e) {
@@ -453,7 +461,7 @@ public final class MorePaths {
      *
      * <h1>Usage</h1>
      * <p>
-     * PathUtils.saveAndBackup(myOriginalFilePath, targetPath ->
+     * MorePaths.saveAndBackup(myOriginalFilePath, targetPath ->
      * JdomHelper.writeJdomToFile(document, targetPath));
      * </p>
      *
@@ -466,16 +474,19 @@ public final class MorePaths {
     public static void saveAndBackup(final Path filePath, final FileWriteHandler fileWriteHandler) throws IOException {
         // Copy original file to temp
         final var temp = copyToTempLocation(filePath);
+        try {
+            // Save data to temp file
+            fileWriteHandler.write(temp);
 
-        // Save data to temp file
-        fileWriteHandler.write(temp);
+            // Create backup from original
+            backupFile(filePath);
 
-        // Create backup from original
-        backupFile(filePath);
-
-        // Replace original with temp file
-        Files.copy(temp, filePath, StandardCopyOption.REPLACE_EXISTING,
-                StandardCopyOption.COPY_ATTRIBUTES);
+            // Replace original with temp file
+            Files.copy(temp, filePath, StandardCopyOption.REPLACE_EXISTING,
+                    StandardCopyOption.COPY_ATTRIBUTES);
+        } finally {
+            deleteQuietly(temp);
+        }
     }
 
     /**

--- a/src/main/java/de/cuioss/tools/io/MorePaths.java
+++ b/src/main/java/de/cuioss/tools/io/MorePaths.java
@@ -348,7 +348,9 @@ public final class MorePaths {
      */
     public static boolean deleteQuietly(final Path path) {
         LOGGER.trace("Deleting file %s", path);
-        if (path == null) {
+        if (path == null || path.toString().isEmpty()) {
+            // An empty path would resolve to the current working directory - never
+            // delete that implicitly
             return false;
         }
         var file = path.toFile();

--- a/src/main/java/de/cuioss/tools/io/UrlLoader.java
+++ b/src/main/java/de/cuioss/tools/io/UrlLoader.java
@@ -25,7 +25,6 @@ import java.io.Serial;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
-import java.net.URLConnection;
 import java.util.concurrent.TimeUnit;
 
 import static de.cuioss.tools.base.Preconditions.checkArgument;
@@ -33,8 +32,9 @@ import static de.cuioss.tools.base.Preconditions.checkArgument;
 /**
  * This {@link FileLoader} takes a {@link URL} as its parameter which is useful
  * when e.g. iterating over an enumeration of URLs from
- * {@link ClassLoader#getResources(String)}. It converts the given URL to a
- * {@code String} and prefixes it with {@link FileTypePrefix#URL}.
+ * {@link ClassLoader#getResources(String)}. When constructed from a
+ * {@code String} it strips an optional {@link FileTypePrefix#URL} prefix and
+ * stores the resulting {@link URL}.
  *
  * @author Sven Haag
  */
@@ -48,12 +48,11 @@ public class UrlLoader implements FileLoader {
     private static final CuiLogger LOGGER = new CuiLogger(UrlLoader.class);
 
     private final URL url;
-    private transient URLConnection connection;
 
     /**
      * @param url representing a valid URL
-     * @throws IllegalArgumentException indicating that the given String represents
-     *                                  a valid URL
+     * @throws IllegalArgumentException indicating that the given String does not
+     *                                  represent a valid URL
      */
     public UrlLoader(final String url) {
         checkArgument(null != url, "url must not be null");
@@ -79,11 +78,9 @@ public class UrlLoader implements FileLoader {
 
     @Override
     public InputStream inputStream() throws IOException {
-        if (null == connection) {
-            connection = url.openConnection();
-            connection.setConnectTimeout((int) TimeUnit.SECONDS.toMillis(5));
-            connection.setReadTimeout((int) TimeUnit.SECONDS.toMillis(5));
-        }
+        final var connection = url.openConnection();
+        connection.setConnectTimeout((int) TimeUnit.SECONDS.toMillis(5));
+        connection.setReadTimeout((int) TimeUnit.SECONDS.toMillis(5));
         return connection.getInputStream();
     }
 

--- a/src/main/java/de/cuioss/tools/io/package-info.java
+++ b/src/main/java/de/cuioss/tools/io/package-info.java
@@ -53,7 +53,7 @@
  * <pre>
  * // Loading classpath resources
  * try {
- *     String content = ClassPathLoader.readFromClasspath("config/app.properties");
+ *     String content = FileLoaderUtility.toString(new ClassPathLoader("classpath:config/app.properties"));
  *     LOGGER.info("Loaded content: %s", content);
  * } catch (IOException e) {
  *     LOGGER.error(e, "Failed to load resource");
@@ -61,8 +61,8 @@
  *
  * // File operations
  * Path file = Paths.get("data.txt");
- * if (MorePaths.checkReadableFile(file)) {
- *     String content = FileLoaderUtility.loadFileFromPath(file);
+ * if (MorePaths.checkReadablePath(file, false, true)) {
+ *     String content = FileLoaderUtility.toStringUnchecked(new FileSystemLoader(file));
  *     LOGGER.info("Loaded file content: %s", content);
  * }
  *

--- a/src/test/java/de/cuioss/tools/io/ClassPathLoaderTest.java
+++ b/src/test/java/de/cuioss/tools/io/ClassPathLoaderTest.java
@@ -85,14 +85,16 @@ class ClassPathLoaderTest {
         assertNotNull(expected);
         var originalLoader = Thread.currentThread().getContextClassLoader();
         try {
-            // ClassLoader#getResource expects names without a leading slash
-            Thread.currentThread().setContextClassLoader(new ClassLoader(null) {
+            // ClassLoader#getResource expects names without a leading slash. The custom
+            // loader keeps the original as parent so class loading through the context
+            // classloader stays intact while this test runs.
+            Thread.currentThread().setContextClassLoader(new ClassLoader(originalLoader) {
                 @Override
                 public URL getResource(String name) {
                     if (contextOnlyResource.equals(name)) {
                         return expected;
                     }
-                    return null;
+                    return super.getResource(name);
                 }
             });
             var loader = new ClassPathLoader(contextOnlyResource);

--- a/src/test/java/de/cuioss/tools/io/ClassPathLoaderTest.java
+++ b/src/test/java/de/cuioss/tools/io/ClassPathLoaderTest.java
@@ -17,6 +17,8 @@ package de.cuioss.tools.io;
 
 import org.junit.jupiter.api.Test;
 
+import java.net.URL;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class ClassPathLoaderTest {
@@ -74,6 +76,31 @@ class ClassPathLoaderTest {
     void shouldFailToLoadNotExistingFile() {
         var classPathLoader = new ClassPathLoader(NOT_EXISTING_CLASSPATH_FILE);
         assertThrows(IllegalStateException.class, classPathLoader::inputStream);
+    }
+
+    @Test
+    void shouldResolveFromContextClassLoader() {
+        var contextOnlyResource = "context-only-resource.txt";
+        var expected = ClassPathLoaderTest.class.getResource(EXISTING_FILE_PATH);
+        assertNotNull(expected);
+        var originalLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            // ClassLoader#getResource expects names without a leading slash
+            Thread.currentThread().setContextClassLoader(new ClassLoader(null) {
+                @Override
+                public URL getResource(String name) {
+                    if (contextOnlyResource.equals(name)) {
+                        return expected;
+                    }
+                    return null;
+                }
+            });
+            var loader = new ClassPathLoader(contextOnlyResource);
+            assertTrue(loader.isReadable());
+            assertEquals(expected, loader.getURL());
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalLoader);
+        }
     }
 
     @Test

--- a/src/test/java/de/cuioss/tools/io/FileLoaderUtilityTest.java
+++ b/src/test/java/de/cuioss/tools/io/FileLoaderUtilityTest.java
@@ -51,6 +51,8 @@ class FileLoaderUtilityTest {
         final var copy = copyFileToTemp(LOADER_EXISTING_FILE_CLASSPATH, true);
         assertNotNull(copy);
         assertTrue(Files.exists(copy));
+        assertTrue(copy.getFileName().toString().endsWith(".txt"),
+                "Temp file should keep the '.txt' extension but was: " + copy.getFileName());
         final var size = Files.size(copy);
         assertTrue(size > 40);
     }

--- a/src/test/java/de/cuioss/tools/io/FileSystemLoaderTest.java
+++ b/src/test/java/de/cuioss/tools/io/FileSystemLoaderTest.java
@@ -70,6 +70,15 @@ class FileSystemLoaderTest {
     }
 
     @Test
+    void shouldHandleExternalFileWithoutLeadingSeparator() throws IOException {
+        final var loader = new FileSystemLoader("external:" + EXISTING_FILE);
+        assertTrue(loader.isReadable(), "external: paths without leading separator should resolve "
+                + "relative to the working directory");
+        assertEquals(EXISTING_FILE, loader.getFileName().getOriginalName());
+        assertNotNull(loader.inputStream());
+    }
+
+    @Test
     void shouldHandleExistingDirectory() {
         final var loader = new FileSystemLoader(EXISTING_DIRECTORY_PATH);
         assertFalse(loader.isReadable());

--- a/src/test/java/de/cuioss/tools/io/FileSystemLoaderTest.java
+++ b/src/test/java/de/cuioss/tools/io/FileSystemLoaderTest.java
@@ -79,6 +79,12 @@ class FileSystemLoaderTest {
     }
 
     @Test
+    void shouldRejectExternalPrefixWithoutPath() {
+        assertThrows(IllegalArgumentException.class, () -> new FileSystemLoader("external:"),
+                "'external:' without an actual path must be rejected");
+    }
+
+    @Test
     void shouldHandleExistingDirectory() {
         final var loader = new FileSystemLoader(EXISTING_DIRECTORY_PATH);
         assertFalse(loader.isReadable());

--- a/src/test/java/de/cuioss/tools/io/IOCaseTest.java
+++ b/src/test/java/de/cuioss/tools/io/IOCaseTest.java
@@ -164,6 +164,44 @@ class IOCaseTest {
         assertEquals(WINDOWS, IOCase.SYSTEM.checkStartsWith("ABC", "abc"));
     }
 
+    @Test
+    void shouldHandleEndsWithEdgeCases() {
+        var testString = Generators.nonEmptyStrings().next();
+        assertTrue(IOCase.SENSITIVE.checkEndsWith(testString, ""));
+        assertFalse(IOCase.SENSITIVE.checkEndsWith("", testString));
+        assertTrue(IOCase.SENSITIVE.checkEndsWith("", ""));
+
+        assertThrows(NullPointerException.class, () -> IOCase.SENSITIVE.checkEndsWith(testString, null));
+        assertThrows(NullPointerException.class, () -> IOCase.SENSITIVE.checkEndsWith(null, testString));
+        assertThrows(NullPointerException.class, () -> IOCase.SENSITIVE.checkEndsWith(null, null));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "ABC,C,true",
+            "ABC,BC,true",
+            "ABC,ABC,true",
+            "ABC,A,false",
+            "ABC,AB,false",
+            "ABC,ABCD,false",
+            "ABC,DABC,false"
+    })
+    void shouldHandleEndsWithVariousSuffixes(String input, String suffix, boolean expected) {
+        assertEquals(expected, IOCase.SENSITIVE.checkEndsWith(input, suffix));
+    }
+
+    @Test
+    void shouldHandleEndsWithDifferentCases() {
+        assertTrue(IOCase.SENSITIVE.checkEndsWith("ABC", "BC"));
+        assertFalse(IOCase.SENSITIVE.checkEndsWith("ABC", "bc"));
+
+        assertTrue(IOCase.INSENSITIVE.checkEndsWith("ABC", "BC"));
+        assertTrue(IOCase.INSENSITIVE.checkEndsWith("ABC", "bc"));
+
+        assertTrue(IOCase.SYSTEM.checkEndsWith("ABC", "BC"));
+        assertEquals(WINDOWS, IOCase.SYSTEM.checkEndsWith("ABC", "bc"));
+    }
+
     private IOCase serialize(IOCase value) throws Exception {
         try (var baos = new ByteArrayOutputStream();
              var oos = new ObjectOutputStream(baos)) {

--- a/src/test/java/de/cuioss/tools/io/MorePathsTest.java
+++ b/src/test/java/de/cuioss/tools/io/MorePathsTest.java
@@ -165,10 +165,39 @@ class MorePathsTest {
 
         assertFalse(Files.exists(playGroundBackup));
         var temp = copyToTempLocation(existing);
-        assertTrue(Files.exists(temp));
+        try {
+            assertTrue(Files.exists(temp));
+            assertTrue(temp.getFileName().toString().endsWith(".xml"),
+                    "Temp file should keep the '.xml' extension but was: " + temp.getFileName());
 
-        MorePaths.contentEquals(existing, temp);
+            assertTrue(MorePaths.contentEquals(existing, temp));
+        } finally {
+            deleteQuietly(temp);
+        }
+    }
 
+    @Test
+    void shouldBackupFileWithoutParent() throws IOException {
+        // Single-segment relative path -> Path#getParent() is null
+        var relativePath = Path.of(
+                "morePathsBackupTest" + FILE_SUFFIX_DATEFORMAT.format(new Date()) + ".txt");
+        Files.copy(TEST_FILE_SOURCE_PATH, relativePath, StandardCopyOption.REPLACE_EXISTING);
+        Path backup = null;
+        try {
+            backup = assertDoesNotThrow(() -> backupFile(relativePath));
+            assertTrue(Files.exists(backup));
+            assertTrue(MorePaths.contentEquals(relativePath, backup));
+        } finally {
+            deleteQuietly(relativePath);
+            if (null != backup) {
+                deleteQuietly(backup);
+                var backupDir = Path.of(BACKUP_DIR_NAME);
+                var children = backupDir.toFile().list();
+                if (null != children && 0 == children.length) {
+                    deleteQuietly(backupDir);
+                }
+            }
+        }
     }
 
     @Test
@@ -261,6 +290,11 @@ class MorePathsTest {
         assertTrue(deleteQuietly(playGroundBase));
         assertFalse(existingFile.toFile().exists());
 
+    }
+
+    @Test
+    void deleteQuietlyShouldNotThrowForEmptyPath() {
+        assertDoesNotThrow(() -> assertFalse(deleteQuietly(Path.of(""))));
     }
 
     @Test

--- a/src/test/java/de/cuioss/tools/io/UrlLoaderTest.java
+++ b/src/test/java/de/cuioss/tools/io/UrlLoaderTest.java
@@ -63,6 +63,37 @@ class UrlLoaderTest {
     }
 
     @Test
+    void shouldProvideInputStreamAfterIsReadable() throws IOException {
+        var url = UrlLoaderTest.class.getResource("/someTestFile.txt");
+        assertNotNull(url, "Test resource not found");
+        var loader = new UrlLoader(url);
+
+        assertTrue(loader.isReadable());
+        try (var stream = loader.inputStream()) {
+            assertTrue(IOStreams.toString(stream).contains("Hello"),
+                    "inputStream() after isReadable() must provide the full content");
+        }
+    }
+
+    @Test
+    void shouldProvideInputStreamMultipleTimes() throws IOException {
+        var url = UrlLoaderTest.class.getResource("/someTestFile.txt");
+        assertNotNull(url, "Test resource not found");
+        var loader = new UrlLoader(url);
+
+        String firstRead;
+        try (var stream = loader.inputStream()) {
+            firstRead = IOStreams.toString(stream);
+        }
+        String secondRead;
+        try (var stream = loader.inputStream()) {
+            secondRead = IOStreams.toString(stream);
+        }
+        assertTrue(firstRead.contains("Hello"));
+        assertEquals(firstRead, secondRead, "Repeated inputStream() calls must provide the same content");
+    }
+
+    @Test
     void shouldGetCorrectFileName() {
         var loader = new UrlLoader("file:/path/to/test.txt");
         var filename = loader.getFileName();


### PR DESCRIPTION
## Summary

Cluster E of the project-analysis fix series (findings catalog: `doc/analysis-findings.md`, IDs IO-1..IO-16).

- **IO-1 (high)**: `UrlLoader` cached its `URLConnection`, and JDK connections hand out the *same* stream instance — so `isReadable()` (which opens and closes the stream) left every subsequent `inputStream()` call with a closed stream ("Stream closed"). This broke the `FileLoader` reentrancy contract and `FileLoaderUtility.copyFileToTemp` for URL sources. Now opens a fresh connection per call.
- **IO-2**: the context-classloader fallback in `ClassPathLoader` passed a leading-slash name to `ClassLoader.getResource()`, which requires slash-less names — the fallback could never succeed. Fixed and pinned with a custom-TCCL test.
- **IO-3**: `MorePaths.backupFile` NPE'd for single-segment relative paths (null parent); now resolves via `toAbsolutePath()`.
- **IO-4**: `deleteQuietly` NPE'd when `File.list()` returned null (I/O error/permission denied), contradicting its "never throws" javadoc.
- **IO-5**: `FileSystemLoader.outputStream()` javadoc claimed it creates missing files — impossible, since `writable` is a construction-time snapshot requiring an existing file (the existing test asserts the opposite of the old doc). Docs now state the real contract.
- **IO-6**: `external:` prefix handling — a swallowed `IOException` let the unprocessed `"external:..."` string flow on as a nonsense path (now fails fast with cause), and the working-directory prefix was concatenated without a separator (`external:conf/app.txt` → `/cwdconf/app.txt`). The prefix is now documented.
- **IO-7**: temp copies passed the suffix without a dot to `createTempFile` (`report…886txt`), mangling the extension consumers dispatch on. Now `"." + suffix`.
- **IO-14**: `saveAndBackup` leaked one temp file per invocation; now cleaned up in a `finally`. Doc referenced nonexistent `PathUtils`.
- **IO-10**: removed `IOCase.readResolve()` and the `transient` modifier — both no-ops for enums (serialized by name).
- **IO-8, IO-9, IO-11..IO-13**: javadoc corrections — package examples called three nonexistent methods; `UrlLoader` class doc described the opposite of its behavior with an inverted `@throws`; wrong exception type on `IOStreams.toString`; "not readable" copy-paste in `FileWriter`; missing leading slash in a `FilenameUtils.concat` example.
- **IO-15/IO-16 (tests)**: `UrlLoader` content reads after `isReadable()` and repeated reads (pins IO-1); first-ever coverage for `IOCase.checkEndsWith` including the longer-suffix edge case; temp-file extension assertions.

## Test plan

- `./mvnw clean install` — BUILD SUCCESS, all tests green (UrlLoaderTest 12/12, IOCaseTest 32/32, MorePathsTest 20/20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKzn4Upj33uRFvWQep3UzE

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKzn4Upj33uRFvWQep3UzE)_