### PR TITLE
net/ssl: fix parameter encoding, faces filtering and keystore contracts

### DIFF
--- a/src/main/java/de/cuioss/tools/net/IDNInternetAddress.java
+++ b/src/main/java/de/cuioss/tools/net/IDNInternetAddress.java
@@ -49,7 +49,7 @@ public class IDNInternetAddress {
      * octets. Display-name segments are not length-limited.
      */
     private static final Pattern addressPatternWithDisplayName = Pattern
-            .compile("(.*)<(.{1,64})@(.{1,255})>(.*)");
+            .compile("([^<]*)<(.{1,64})@(.{1,255})>([^>]*)");
 
     private static final Pattern addressPattern = Pattern.compile("(.{1,64})@(.{1,255})");
 
@@ -76,13 +76,27 @@ public class IDNInternetAddress {
         var matcher = addressPatternWithDisplayName.matcher(completeAddress);
         if (matcher.matches()) {
             return sanitizer.apply(matcher.group(1)) + "<" + sanitizer.apply(matcher.group(2)) + "@"
-                    + sanitizer.apply(IDN.toASCII(matcher.group(3))) + ">" + sanitizer.apply(matcher.group(4));
+                    + sanitizer.apply(toAsciiSafely(matcher.group(3))) + ">" + sanitizer.apply(matcher.group(4));
         }
         matcher = addressPattern.matcher(completeAddress);
         if (matcher.matches()) {
-            return sanitizer.apply(matcher.group(1)) + "@" + sanitizer.apply(IDN.toASCII(matcher.group(2)));
+            return sanitizer.apply(matcher.group(1)) + "@" + sanitizer.apply(toAsciiSafely(matcher.group(2)));
         }
         return sanitizer.apply(completeAddress);
+    }
+
+    /**
+     * {@link IDN#toASCII(String)} throws an (undocumented) IllegalArgumentException
+     * for domains that match the address patterns but are invalid for IDN (e.g.
+     * empty labels like {@code domain..com}). Fall back to the unconverted domain
+     * in that case, keeping this utility robust against untrusted input.
+     */
+    private static String toAsciiSafely(final String domain) {
+        try {
+            return IDN.toASCII(domain);
+        } catch (IllegalArgumentException e) {
+            return domain;
+        }
     }
 
     /**

--- a/src/main/java/de/cuioss/tools/net/IDNInternetAddress.java
+++ b/src/main/java/de/cuioss/tools/net/IDNInternetAddress.java
@@ -44,10 +44,14 @@ import java.util.regex.Pattern;
 @UtilityClass
 public class IDNInternetAddress {
 
+    /**
+     * RFC 5321 limits the local part to 64 octets, the domain may be up to 255
+     * octets. Display-name segments are not length-limited.
+     */
     private static final Pattern addressPatternWithDisplayName = Pattern
-            .compile("(.{0,64})<(.{1,64})@(.{1,64})>(.{0,64})");
+            .compile("(.*)<(.{1,64})@(.{1,255})>(.*)");
 
-    private static final Pattern addressPattern = Pattern.compile("(.{1,64})@(.{1,64})");
+    private static final Pattern addressPattern = Pattern.compile("(.{1,64})@(.{1,255})");
 
     /**
      * Encode the domain part of an email address
@@ -70,12 +74,12 @@ public class IDNInternetAddress {
      */
     public static String encode(@NonNull final String completeAddress, UnaryOperator<String> sanitizer) {
         var matcher = addressPatternWithDisplayName.matcher(completeAddress);
-        if (matcher.matches() && matcher.groupCount() == 4) {
+        if (matcher.matches()) {
             return sanitizer.apply(matcher.group(1)) + "<" + sanitizer.apply(matcher.group(2)) + "@"
                     + sanitizer.apply(IDN.toASCII(matcher.group(3))) + ">" + sanitizer.apply(matcher.group(4));
         }
         matcher = addressPattern.matcher(completeAddress);
-        if (matcher.matches() && matcher.groupCount() == 2) {
+        if (matcher.matches()) {
             return sanitizer.apply(matcher.group(1)) + "@" + sanitizer.apply(IDN.toASCII(matcher.group(2)));
         }
         return sanitizer.apply(completeAddress);
@@ -103,12 +107,12 @@ public class IDNInternetAddress {
      */
     public static String decode(@NonNull final String completeAddress, UnaryOperator<String> sanitizer) {
         var matcher = addressPatternWithDisplayName.matcher(completeAddress);
-        if (matcher.matches() && matcher.groupCount() == 4) {
+        if (matcher.matches()) {
             return sanitizer.apply(matcher.group(1)) + "<" + sanitizer.apply(matcher.group(2)) + "@"
                     + sanitizer.apply(IDN.toUnicode(matcher.group(3))) + ">" + sanitizer.apply(matcher.group(4));
         }
         matcher = addressPattern.matcher(completeAddress);
-        if (matcher.matches() && matcher.groupCount() == 2) {
+        if (matcher.matches()) {
             return sanitizer.apply(matcher.group(1)) + "@" + sanitizer.apply(IDN.toUnicode(matcher.group(2)));
         }
         return sanitizer.apply(completeAddress);

--- a/src/main/java/de/cuioss/tools/net/IDNInternetAddress.java
+++ b/src/main/java/de/cuioss/tools/net/IDNInternetAddress.java
@@ -18,6 +18,8 @@ package de.cuioss.tools.net;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
 
+import de.cuioss.tools.logging.CuiLogger;
+
 import java.net.IDN;
 import java.util.function.UnaryOperator;
 import java.util.regex.Pattern;
@@ -43,6 +45,8 @@ import java.util.regex.Pattern;
  */
 @UtilityClass
 public class IDNInternetAddress {
+
+    private static final CuiLogger LOGGER = new CuiLogger(IDNInternetAddress.class);
 
     /**
      * RFC 5321 limits the local part to 64 octets, the domain may be up to 255
@@ -95,6 +99,7 @@ public class IDNInternetAddress {
         try {
             return IDN.toASCII(domain);
         } catch (IllegalArgumentException e) {
+            LOGGER.trace(e, "IDN.toASCII failed for domain '%s', using unconverted value", domain);
             return domain;
         }
     }

--- a/src/main/java/de/cuioss/tools/net/ParameterFilter.java
+++ b/src/main/java/de/cuioss/tools/net/ParameterFilter.java
@@ -20,12 +20,14 @@ import lombok.*;
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Defines a filter identifying which parameters are not to be included within
  * url parameter handling. Therefore, it filters parameter prefixed with
- * "javax.faces", depending on <code>excludeFacesParameter</code> and
- * additionally a given list of parameter names.
+ * "javax.faces" or "jakarta.faces", depending on
+ * <code>excludeFacesParameter</code> and additionally a given list of parameter
+ * names.
  *
  * @author Oliver Wolff
  */
@@ -38,6 +40,8 @@ public class ParameterFilter implements Serializable {
     private static final long serialVersionUID = -4780294784318006024L;
 
     private static final String JAVAX_FACES = "javax.faces";
+
+    private static final String JAKARTA_FACES = "jakarta.faces";
 
     /**
      * The list of string to be excluded from the parameter-list. Because the test
@@ -58,10 +62,10 @@ public class ParameterFilter implements Serializable {
     public boolean isExcluded(@NonNull final String value) {
         var excluded = false;
         if (excludeFacesParameter) {
-            excluded = value.startsWith(JAVAX_FACES);
+            excluded = value.startsWith(JAVAX_FACES) || value.startsWith(JAKARTA_FACES);
         }
         if (!excluded) {
-            excluded = excludes.contains(value.toLowerCase());
+            excluded = excludes.contains(value.toLowerCase(Locale.ROOT));
         }
         return excluded;
     }

--- a/src/main/java/de/cuioss/tools/net/UrlHelper.java
+++ b/src/main/java/de/cuioss/tools/net/UrlHelper.java
@@ -139,16 +139,20 @@ public final class UrlHelper {
 
     /**
      * @param uri value to be verified if it is a valid URI.
-     * @return true, if the given value is a valid URI. False otherwise.
+     * @return true, if the given value is a valid URI. False otherwise, especially
+     *         for {@code null} or empty input, consistent with
+     *         {@link #tryParseUri(String)}.
      */
     public boolean isValidUri(final String uri) {
-        if (!MoreStrings.isEmpty(uri)) {
-            try {
-                new URI(uri);
-            } catch (URISyntaxException e) {
-                return false;
-            }
+        if (MoreStrings.isEmpty(uri)) {
+            return false;
         }
-        return true;
+        try {
+            new URI(uri);
+            return true;
+        } catch (URISyntaxException e) {
+            LOGGER.trace(e, "Invalid URI");
+            return false;
+        }
     }
 }

--- a/src/main/java/de/cuioss/tools/net/UrlHelper.java
+++ b/src/main/java/de/cuioss/tools/net/UrlHelper.java
@@ -144,15 +144,6 @@ public final class UrlHelper {
      *         {@link #tryParseUri(String)}.
      */
     public boolean isValidUri(final String uri) {
-        if (MoreStrings.isEmpty(uri)) {
-            return false;
-        }
-        try {
-            new URI(uri);
-            return true;
-        } catch (URISyntaxException e) {
-            LOGGER.trace(e, "Invalid URI");
-            return false;
-        }
+        return tryParseUri(uri).isPresent();
     }
 }

--- a/src/main/java/de/cuioss/tools/net/UrlParameter.java
+++ b/src/main/java/de/cuioss/tools/net/UrlParameter.java
@@ -71,7 +71,7 @@ public class UrlParameter implements Serializable, Comparable<UrlParameter> {
      * Flag indicating whether name and value are stored in URL-encoded form. Used
      * to prevent double-encoding when creating encoded parameter-strings.
      */
-    private final boolean encoded;
+    private final Boolean encoded;
 
     /**
      * Constructor. Name and value are implicitly encoded using UTF-8.
@@ -311,7 +311,10 @@ public class UrlParameter implements Serializable, Comparable<UrlParameter> {
      * @return string representation of name + value
      */
     public String createNameValueString(final boolean encode) {
-        if (encode && !encoded) {
+        // Boolean (not boolean): instances serialized by older library versions
+        // deserialize with encoded == null; those were always stored encoded, so
+        // only re-encode when the flag is explicitly false.
+        if (encode && Boolean.FALSE.equals(encoded)) {
             var encodedName = encode(name, StandardCharsets.UTF_8);
             String encodedValue = null;
             if (null != value) {

--- a/src/main/java/de/cuioss/tools/net/UrlParameter.java
+++ b/src/main/java/de/cuioss/tools/net/UrlParameter.java
@@ -50,8 +50,8 @@ import static java.util.Objects.requireNonNull;
  *
  * @author Oliver Wolff
  */
-@EqualsAndHashCode
-@ToString
+@EqualsAndHashCode(of = {"name", "value"})
+@ToString(of = {"name", "value"})
 public class UrlParameter implements Serializable, Comparable<UrlParameter> {
 
     private static final CuiLogger LOGGER = new CuiLogger(UrlParameter.class);
@@ -66,6 +66,12 @@ public class UrlParameter implements Serializable, Comparable<UrlParameter> {
     /** The value of the parameter. */
     @Getter
     private final String value;
+
+    /**
+     * Flag indicating whether name and value are stored in URL-encoded form. Used
+     * to prevent double-encoding when creating encoded parameter-strings.
+     */
+    private final boolean encoded;
 
     /**
      * Constructor. Name and value are implicitly encoded using UTF-8.
@@ -98,6 +104,7 @@ public class UrlParameter implements Serializable, Comparable<UrlParameter> {
             this.name = name;
             this.value = value;
         }
+        encoded = encode;
     }
 
     /**
@@ -112,8 +119,9 @@ public class UrlParameter implements Serializable, Comparable<UrlParameter> {
 
     /**
      * Creates a parameter String for a given number of {@link UrlParameter}.
+     * {@code null} elements will be skipped.
      *
-     * @param parameters to be appended, must not be null
+     * @param parameters to be appended, may be null
      * @return the concatenated ParameterString in the form
      *         "?parameter1Name=parameter1Value&amp;parameter2Name=parameter2Value"
      */
@@ -122,22 +130,24 @@ public class UrlParameter implements Serializable, Comparable<UrlParameter> {
     }
 
     /**
-     * Create a String-representation of the URL-Parameter
+     * Create a String-representation of the URL-Parameter. {@code null} elements
+     * will be skipped.
      *
      * @param encode indicating whether the string elements should be encoded or not
-     * @param parameters to be appended, must not be null
+     * @param parameters to be appended, may be null
      * @return the created parameter String
      */
     public static String createParameterString(final boolean encode, final UrlParameter... parameters) {
         final var builder = new StringBuilder();
-        // First parameter to be treated specially.
-        if (null != parameters && parameters.length > 0 && null != parameters[0]) {
-            builder.append('?').append(parameters[0].createNameValueString(encode));
-            if (parameters.length > 1) {
-                // The other parameters are appended with '&'
-                for (var i = 1; i < parameters.length; i++) {
-                    builder.append('&').append(parameters[i].createNameValueString(encode));
+        if (null != parameters) {
+            var first = true;
+            for (final UrlParameter parameter : parameters) {
+                if (null == parameter) {
+                    continue;
                 }
+                // The first parameter is prefixed with '?', the others with '&'
+                builder.append(first ? '?' : '&').append(parameter.createNameValueString(encode));
+                first = false;
             }
         }
         return builder.toString();
@@ -211,8 +221,10 @@ public class UrlParameter implements Serializable, Comparable<UrlParameter> {
      * Create a parameterMap for a given list of {@link UrlParameter}
      *
      * @param urlParameters may be null or empty
-     * @return parameter Map, may be empty if urlParameters is empty. The list of
-     *         String will solely contain one element.
+     * @return parameter Map, may be empty if urlParameters is empty. For a
+     *         parameter providing a value, the corresponding list contains solely
+     *         that one element. For a parameter without a value ({@code null}) the
+     *         corresponding list is empty.
      */
     public static Map<String, List<String>> createParameterMap(final List<UrlParameter> urlParameters) {
         final Map<String, List<String>> result = new HashMap<>();
@@ -250,28 +262,21 @@ public class UrlParameter implements Serializable, Comparable<UrlParameter> {
         var elements = Splitter.on(Pattern.compile("&")).trimResults().omitEmptyStrings().splitToList(cleaned);
         var builder = new CollectionBuilder<UrlParameter>();
         for (String element : elements) {
-            if (element.contains("=")) {
-                var splitted = Splitter.on(Pattern.compile("=")).omitEmptyStrings().splitToList(element);
-                switch (splitted.size()) {
-                    case 0:
-                        LOGGER.debug(
-                                "Unable to parse queryString '%s' correctly, unable to extract key-value-pair for element '%s'",
-                                queryString, element);
-                        break;
-                    case 1:
-                        builder.add(createDecoded(splitted.getFirst(), null));
-                        break;
-                    case 2:
-                        builder.add(createDecoded(splitted.getFirst(), splitted.getLast()));
-                        break;
-                    default:
-                        LOGGER.debug(
-                                "Unable to parse queryString '%s' correctly, multiple '=' symbols found at unexpected locations",
-                                queryString);
-                        break;
-                }
-            } else {
+            // Split on the first '=' only: values may contain literal '=' characters,
+            // e.g. Base64-encoded content
+            var separatorIndex = element.indexOf('=');
+            if (separatorIndex < 0) {
                 builder.add(createDecoded(element, null));
+            } else {
+                var name = element.substring(0, separatorIndex);
+                var value = element.substring(separatorIndex + 1);
+                if (MoreStrings.isEmpty(name)) {
+                    LOGGER.debug(
+                            "Unable to parse queryString '%s' correctly, element '%s' provides no parameter name, skipping",
+                            queryString, element);
+                } else {
+                    builder.add(createDecoded(name, MoreStrings.isEmpty(value) ? null : value));
+                }
             }
         }
         return builder.toImmutableList();
@@ -300,12 +305,19 @@ public class UrlParameter implements Serializable, Comparable<UrlParameter> {
     }
 
     /**
-     * @param encode flag indicate if the result need to be encoded
-     * @return string representation of name + vale
+     * @param encode flag indicating whether the result needs to be encoded. If the
+     *               parameter was already encoded at construction time it will not
+     *               be encoded again, ensuring single-encoded output
+     * @return string representation of name + value
      */
     public String createNameValueString(final boolean encode) {
-        if (encode) {
-            return new UrlParameter(name, value).createNameValueString();
+        if (encode && !encoded) {
+            var encodedName = encode(name, StandardCharsets.UTF_8);
+            String encodedValue = null;
+            if (null != value) {
+                encodedValue = encode(value, StandardCharsets.UTF_8);
+            }
+            return Joiner.on('=').useForNull("").join(encodedName, encodedValue);
         }
         return Joiner.on('=').useForNull("").join(name, value);
     }

--- a/src/main/java/de/cuioss/tools/net/ssl/KeyMaterialHolder.java
+++ b/src/main/java/de/cuioss/tools/net/ssl/KeyMaterialHolder.java
@@ -32,7 +32,7 @@ import java.util.Base64;
 // KeyMaterialHolder and KeyStoreProvider are in the SAME package (de.cuioss.tools.net.ssl).
 // This is an intentional design where these classes work together to manage SSL key material.
 @Builder
-@EqualsAndHashCode(exclude = {"keyMaterial", "keyPassword"}, doNotUseGetters = true)
+@EqualsAndHashCode(exclude = "keyPassword", doNotUseGetters = true)
 @ToString(exclude = {"keyMaterial", "keyPassword"}, doNotUseGetters = true)
 public final class KeyMaterialHolder implements Serializable {
 

--- a/src/main/java/de/cuioss/tools/net/ssl/KeyStoreProvider.java
+++ b/src/main/java/de/cuioss/tools/net/ssl/KeyStoreProvider.java
@@ -15,7 +15,6 @@
  */
 package de.cuioss.tools.net.ssl;
 
-import de.cuioss.tools.base.BooleanOperations;
 import de.cuioss.tools.io.MorePaths;
 import de.cuioss.tools.logging.CuiLogger;
 import lombok.Builder;
@@ -67,7 +66,7 @@ import static java.util.Objects.requireNonNull;
  *
  */
 @Builder
-@EqualsAndHashCode(of = {"keyStoreType", "location"}, doNotUseGetters = true)
+@EqualsAndHashCode(of = {"keyStoreType", "location", "keys"}, doNotUseGetters = true)
 @ToString(of = {"keyStoreType", "location"}, doNotUseGetters = true)
 public class KeyStoreProvider implements Serializable {
 
@@ -104,25 +103,25 @@ public class KeyStoreProvider implements Serializable {
 
     /**
      * Creates a new {@link KeyStore} using the configured parameters.
-     * If key materials are provided, they will be used to create the store.
+     * If key materials are provided, they will be used to create the store and a
+     * configured file location will be ignored.
      * Otherwise, the store will be loaded from the configured file location.
      *
-     * @return a new {@link KeyStore} instance
+     * @return a new {@link KeyStore} instance, or {@link Optional#empty()} if
+     *         neither a file location nor key material is configured
      * @throws IllegalStateException if the store cannot be created or loaded
      */
     public Optional<KeyStore> resolveKeyStore() {
-        if (BooleanOperations.areAllTrue(keys.isEmpty(), null == location)) {
-            LOGGER.debug("Neither file nor keyMaterial provided, returning Optional#empty");
-            return Optional.empty();
-        }
-        if (null != location) {
-            LOGGER.debug("Checking whether configured %s path is readable", location.getAbsolutePath());
-            checkState(MorePaths.checkReadablePath(location.toPath(), false, true),
-                    "'%s' is not readable check logs for reason", location.getAbsolutePath());
-        }
         if (!keys.isEmpty()) {
             return retrieveFromKeys();
         }
+        if (null == location) {
+            LOGGER.debug("Neither file nor keyMaterial provided, returning Optional#empty");
+            return Optional.empty();
+        }
+        LOGGER.debug("Checking whether configured %s path is readable", location.getAbsolutePath());
+        checkState(MorePaths.checkReadablePath(location.toPath(), false, true),
+                "'%s' is not readable check logs for reason", location.getAbsolutePath());
         return retrieveFromFile();
     }
 
@@ -182,8 +181,17 @@ public class KeyStoreProvider implements Serializable {
         } catch (KeyStoreException e) {
             throw new IllegalStateException("Unable to instantiate KeyStore", e);
         }
+        // For KeyHolderType#KEY_STORE the keyPassword of the holder is documented as
+        // being the store-password of the embedded keystore. Fall back to the
+        // provider's storePassword if the holder does not provide one.
+        char[] embeddedStorePassword;
+        if (isEmpty(key.getKeyPassword())) {
+            embeddedStorePassword = getStorePasswordAsCharArray();
+        } else {
+            embeddedStorePassword = key.getKeyPasswordAsCharArray();
+        }
         try (InputStream keyStoreStream = new ByteArrayInputStream(key.getKeyMaterial())) {
-            keyStore.load(keyStoreStream, getStorePasswordAsCharArray());
+            keyStore.load(keyStoreStream, embeddedStorePassword);
             return keyStore;
         } catch (NoSuchAlgorithmException | CertificateException | IOException e) {
             throw new IllegalStateException(UNABLE_TO_CREATE_KEYSTORE, e);

--- a/src/test/java/de/cuioss/tools/net/IDNInternetAddressTest.java
+++ b/src/test/java/de/cuioss/tools/net/IDNInternetAddressTest.java
@@ -17,7 +17,10 @@ package de.cuioss.tools.net;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class IDNInternetAddressTest {
 
@@ -45,6 +48,62 @@ class IDNInternetAddressTest {
         orig = "user1@müller.com";
         assertEquals("user1@xn--mller-kva.com", IDNInternetAddress.encode(orig));
         assertEquals(orig, IDNInternetAddress.decode(IDNInternetAddress.encode(orig)));
+    }
+
+    @Test
+    void shouldHandleDomainsLongerThan64Characters() {
+        // RFC 5321 permits domains of up to 255 characters, each label up to 63
+        final var longLabel = "a".repeat(50);
+        final var domain = "müller." + longLabel + ".example.com";
+        assertTrue(domain.length() > 64);
+
+        var orig = "user1@" + domain;
+        var encoded = IDNInternetAddress.encode(orig);
+        assertEquals("user1@xn--mller-kva." + longLabel + ".example.com", encoded);
+        assertEquals(orig, IDNInternetAddress.decode(encoded));
+
+        orig = "MD KARIN KALLWITZ <user1@" + domain + ">";
+        encoded = IDNInternetAddress.encode(orig);
+        assertEquals("MD KARIN KALLWITZ <user1@xn--mller-kva." + longLabel + ".example.com>", encoded);
+        assertEquals(orig, IDNInternetAddress.decode(encoded));
+    }
+
+    @Test
+    void shouldHandleDisplayNamesLongerThan64Characters() {
+        final var displayName = "M".repeat(70);
+        final var orig = displayName + " <user1@müller.com>";
+        final var encoded = IDNInternetAddress.encode(orig);
+        assertEquals(displayName + " <user1@xn--mller-kva.com>", encoded);
+        assertEquals(orig, IDNInternetAddress.decode(encoded));
+    }
+
+    @Test
+    void shouldApplySanitizerOnEncode() {
+        assertEquals("USER1@XN--MLLER-KVA.COM",
+                IDNInternetAddress.encode("user1@müller.com", value -> value.toUpperCase(Locale.ROOT)));
+        assertEquals("MD KARIN KALLWITZ <USER1@XN--MLLER-KVA.COM>",
+                IDNInternetAddress.encode("md karin kallwitz <user1@müller.com>",
+                        value -> value.toUpperCase(Locale.ROOT)));
+    }
+
+    @Test
+    void shouldApplySanitizerOnDecode() {
+        assertEquals("USER1@MÜLLER.COM",
+                IDNInternetAddress.decode("user1@xn--mller-kva.com", value -> value.toUpperCase(Locale.ROOT)));
+        assertEquals("MD KARIN KALLWITZ <USER1@MÜLLER.COM>",
+                IDNInternetAddress.decode("md karin kallwitz <user1@xn--mller-kva.com>",
+                        value -> value.toUpperCase(Locale.ROOT)));
+    }
+
+    @Test
+    void shouldReturnNonMatchingInputSanitizedButUnmodified() {
+        // Neither pattern matches input without an '@' character
+        assertEquals("no-mail-address", IDNInternetAddress.encode("no-mail-address"));
+        assertEquals("no-mail-address", IDNInternetAddress.decode("no-mail-address"));
+        assertEquals("NO-MAIL-ADDRESS",
+                IDNInternetAddress.encode("no-mail-address", value -> value.toUpperCase(Locale.ROOT)));
+        assertEquals("NO-MAIL-ADDRESS",
+                IDNInternetAddress.decode("no-mail-address", value -> value.toUpperCase(Locale.ROOT)));
     }
 
 }

--- a/src/test/java/de/cuioss/tools/net/ParameterFilterTest.java
+++ b/src/test/java/de/cuioss/tools/net/ParameterFilterTest.java
@@ -28,14 +28,17 @@ class ParameterFilterTest {
 
     private static final String JAVAX_FACES = "javax.faces";
 
+    private static final String JAKARTA_FACES = "jakarta.faces";
+
     private static final List<String> EXCLUDES = immutableList("a", "b", "c");
     private static final List<String> INCLUDES = immutableList("d", "e", "f", "af", "fa");
 
     private static final List<String> FACES_INCLUDES = immutableList("d" + JAVAX_FACES, "e" + JAVAX_FACES,
-            "f" + JAVAX_FACES);
+            "f" + JAVAX_FACES, "d" + JAKARTA_FACES, "e" + JAKARTA_FACES);
 
     private static final List<String> FACES_EXCLUDES = immutableList(JAVAX_FACES + "a", JAVAX_FACES + "." + "b",
-            JAVAX_FACES + "-" + "c");
+            JAVAX_FACES + "-" + "c", JAKARTA_FACES + ".ViewState", JAKARTA_FACES + ".ClientWindow",
+            JAKARTA_FACES + "-" + "c");
 
     @Test
     void shouldExludeAndIncludeStrings() {
@@ -55,6 +58,14 @@ class ParameterFilterTest {
             assertTrue(filter.isExcluded(exclude));
         }
         for (final String include : FACES_INCLUDES) {
+            assertFalse(filter.isExcluded(include));
+        }
+    }
+
+    @Test
+    void shouldNotExcludeFacesStringsIfDisabled() {
+        final var filter = new ParameterFilter(EXCLUDES, false);
+        for (final String include : FACES_EXCLUDES) {
             assertFalse(filter.isExcluded(include));
         }
     }

--- a/src/test/java/de/cuioss/tools/net/UrlHelperTest.java
+++ b/src/test/java/de/cuioss/tools/net/UrlHelperTest.java
@@ -106,8 +106,8 @@ class UrlHelperTest {
 
     @Test
     void shouldHandleNullAndEmptyForUriValidation() {
-        assertTrue(assertDoesNotThrow(() -> isValidUri("")));
-        assertTrue(assertDoesNotThrow(() -> isValidUri(null)));
+        assertFalse(assertDoesNotThrow(() -> isValidUri("")));
+        assertFalse(assertDoesNotThrow(() -> isValidUri(null)));
 
         Optional<URI> emptyResult = assertDoesNotThrow(() -> tryParseUri(""));
         assertTrue(emptyResult.isEmpty());

--- a/src/test/java/de/cuioss/tools/net/UrlParameterTest.java
+++ b/src/test/java/de/cuioss/tools/net/UrlParameterTest.java
@@ -84,6 +84,33 @@ class UrlParameterTest {
     }
 
     @Test
+    void createParameterStringShouldSkipNullElements() {
+        final var parameter1 = new UrlParameter("name1", "value1");
+        final var parameter2 = new UrlParameter("name2", "value2");
+        assertEquals("", UrlParameter.createParameterString((UrlParameter[]) null));
+        assertEquals("", UrlParameter.createParameterString((UrlParameter) null));
+        assertEquals("?name2=value2", UrlParameter.createParameterString(null, parameter2));
+        assertEquals("?name1=value1", UrlParameter.createParameterString(parameter1, null));
+        assertEquals("?name1=value1&name2=value2",
+                UrlParameter.createParameterString(parameter1, null, parameter2));
+    }
+
+    @Test
+    void createParameterStringShouldSingleEncode() {
+        // Constructed with implicit encoding: fields are stored already encoded
+        final var encodedAtConstruction = new UrlParameter("b c", "v& 1");
+        assertEquals("b+c", encodedAtConstruction.getName());
+        assertEquals("v%26+1", encodedAtConstruction.getValue());
+        assertEquals("?b+c=v%26+1", UrlParameter.createParameterString(true, encodedAtConstruction));
+        // Constructed without encoding: fields are stored raw and encoded on demand
+        final var raw = new UrlParameter("b c", "v& 1", false);
+        assertEquals("?b+c=v%26+1", UrlParameter.createParameterString(true, raw));
+        // The encode=false path emits the stored fields unmodified
+        assertEquals("?b+c=v%26+1", UrlParameter.createParameterString(false, encodedAtConstruction));
+        assertEquals("?b c=v& 1", UrlParameter.createParameterString(false, raw));
+    }
+
+    @Test
     void testGetUrlParameterFromMap() {
         assertTrue(getUrlParameterFromMap(null, null, true).isEmpty());
         assertTrue(getUrlParameterFromMap(new HashMap<>(), null, true).isEmpty());
@@ -200,9 +227,27 @@ class UrlParameterTest {
         assertTrue(fromQueryString(null).isEmpty());
         assertTrue(fromQueryString("?").isEmpty());
         assertTrue(fromQueryString("=").isEmpty());
-        assertTrue(fromQueryString("a=b=c").isEmpty());
         assertTrue(fromQueryString("?=").isEmpty());
         assertTrue(fromQueryString("?&").isEmpty());
+        // Pairs without a name are invalid and therefore skipped
+        assertTrue(fromQueryString("=foo").isEmpty());
+        assertTrue(fromQueryString("?=foo").isEmpty());
+    }
+
+    @Test
+    void parseQueryParameterShouldHandleValueContainingEquals() {
+        var fromQueryString = fromQueryString("a=b=c");
+        assertEquals(1, fromQueryString.size());
+        var urlParameter = fromQueryString.getFirst();
+        assertEquals("a", urlParameter.getName());
+        assertEquals("b=c", urlParameter.getValue());
+
+        // Typical Base64 padding
+        fromQueryString = fromQueryString("token=YWJj0Q==");
+        assertEquals(1, fromQueryString.size());
+        urlParameter = fromQueryString.getFirst();
+        assertEquals("token", urlParameter.getName());
+        assertEquals("YWJj0Q==", urlParameter.getValue());
     }
 
     @Test

--- a/src/test/java/de/cuioss/tools/net/UrlParameterTest.java
+++ b/src/test/java/de/cuioss/tools/net/UrlParameterTest.java
@@ -293,4 +293,17 @@ class UrlParameterTest {
     void shouldBehaveWell() {
         ObjectMethodsAsserts.assertNiceObject(new UrlParameter("name3", "value3"));
     }
+
+    @Test
+    void createNameValueStringShouldTreatLegacyNullEncodedFlagAsEncoded() throws Exception {
+        // Instances serialized by older library versions deserialize with encoded == null;
+        // they were always stored encoded, so no re-encoding must happen
+        var parameter = new UrlParameter("name", "value%20with%20spaces", false);
+        var encodedField = UrlParameter.class.getDeclaredField("encoded");
+        encodedField.setAccessible(true);
+        encodedField.set(parameter, null);
+
+        assertEquals("name=value%20with%20spaces", parameter.createNameValueString(true),
+                "Legacy instances (encoded == null) must not be re-encoded");
+    }
 }

--- a/src/test/java/de/cuioss/tools/net/ssl/KeyMaterialHolderTest.java
+++ b/src/test/java/de/cuioss/tools/net/ssl/KeyMaterialHolderTest.java
@@ -68,6 +68,25 @@ class KeyMaterialHolderTest {
     }
 
     @Test
+    void shouldIncludeKeyMaterialInEqualsAndHashCode() {
+        var material = new byte[]{1, 2, 3};
+        var differentMaterial = new byte[]{4, 5, 6};
+
+        var holder = KeyMaterialHolder.builder().keyMaterial(material).build();
+        var sameMaterial = KeyMaterialHolder.builder().keyMaterial(material.clone()).build();
+        var otherMaterial = KeyMaterialHolder.builder().keyMaterial(differentMaterial).build();
+
+        assertEquals(holder, sameMaterial);
+        assertEquals(holder.hashCode(), sameMaterial.hashCode());
+        assertNotEquals(holder, otherMaterial);
+
+        // keyPassword remains excluded from equals / hashCode
+        var withPassword = KeyMaterialHolder.builder().keyMaterial(material).keyPassword("secret").build();
+        assertEquals(holder, withPassword);
+        assertEquals(holder.hashCode(), withPassword.hashCode());
+    }
+
+    @Test
     void shouldBehaveWell() {
         ObjectMethodsAsserts.assertNiceObject(withRandomKeyMaterial()
                 .name(Generators.nonEmptyStrings().next())

--- a/src/test/java/de/cuioss/tools/net/ssl/KeyStoreProviderTest.java
+++ b/src/test/java/de/cuioss/tools/net/ssl/KeyStoreProviderTest.java
@@ -143,6 +143,46 @@ class KeyStoreProviderTest {
     }
 
     @Test
+    void shouldUseHolderKeyPasswordAsStorePasswordForEmbeddedKeyStore() throws Exception {
+
+        var keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        keyStore.load(null, null);
+
+        var os = new ByteArrayOutputStream();
+        keyStore.store(os, "holderPassword".toCharArray());
+
+        // The holder's keyPassword is documented as being the store-password for
+        // KeyHolderType#KEY_STORE. The provider's storePassword differs and must not
+        // be used for loading the embedded keystore.
+        var keyHolder = KeyMaterialHolder.builder().keyAlias("KeyStore").keyHolderType(KeyHolderType.KEY_STORE)
+                .keyPassword("holderPassword").keyMaterial(os.toByteArray()).build();
+
+        var provider = KeyStoreProvider.builder().keyStoreType(KeyStoreType.KEY_STORE)
+                .storePassword("differentStorePassword").key(keyHolder).build();
+
+        var ky = assertDoesNotThrow(provider::resolveKeyStore);
+        assertTrue(ky.isPresent());
+        assertTrue(ky.get().size() < 1);
+    }
+
+    @Test
+    void shouldIgnoreLocationIfKeyMaterialIsPresent() throws Exception {
+
+        var x509Certificate = createX509Certificate("EC", 256, "SHA256withECDSA");
+
+        var keyHolder = KeyMaterialHolder.builder().keyAlias("EC256").keyAlgorithm(KeyAlgorithm.ECDSA_P_256)
+                .keyMaterial(x509Certificate.getEncoded()).build();
+
+        // The not-readable location must be ignored because key material is present
+        var provider = KeyStoreProvider.builder().keyStoreType(KeyStoreType.TRUST_STORE).storePassword("StorePassword")
+                .location(new File("notThere")).key(keyHolder).build();
+
+        var ky = assertDoesNotThrow(provider::resolveKeyStore);
+        assertTrue(ky.isPresent());
+        assertEquals(x509Certificate.getPublicKey(), ky.get().getCertificate("EC256").getPublicKey());
+    }
+
+    @Test
     void shouldFailOnEmptyKeyStores() {
         var keyHolder = KeyMaterialHolder.builder().keyAlias("KeyStore").keyAlgorithm(KeyAlgorithm.RSA_2048)
                 .keyHolderType(KeyHolderType.KEY_STORE).keyMaterial(new byte[1]).build();
@@ -275,6 +315,37 @@ class KeyStoreProviderTest {
 
         assertEquals(generatedStorePassword.length(), provider.getStorePasswordAsCharArray().length);
         assertEquals(0, provider.getKeyPasswordAsCharArray().length);
+    }
+
+    @Test
+    void shouldProvideKeyOrStorePassword() {
+        var provider = KeyStoreProvider.builder().keyStoreType(KeyStoreType.KEY_STORE).build();
+        assertEquals(0, provider.getKeyOrStorePassword().length);
+
+        provider = KeyStoreProvider.builder().keyStoreType(KeyStoreType.KEY_STORE).storePassword("store").build();
+        assertArrayEquals("store".toCharArray(), provider.getKeyOrStorePassword());
+
+        provider = KeyStoreProvider.builder().keyStoreType(KeyStoreType.KEY_STORE).storePassword("store")
+                .keyPassword("key").build();
+        assertArrayEquals("key".toCharArray(), provider.getKeyOrStorePassword());
+
+        provider = KeyStoreProvider.builder().keyStoreType(KeyStoreType.KEY_STORE).keyPassword("key").build();
+        assertArrayEquals("key".toCharArray(), provider.getKeyOrStorePassword());
+    }
+
+    @Test
+    void shouldIncludeKeysInEqualsAndHashCode() {
+        var keyHolder1 = KeyMaterialHolder.builder().keyMaterial(new byte[]{1, 2, 3}).build();
+        var keyHolder2 = KeyMaterialHolder.builder().keyMaterial(new byte[]{4, 5, 6}).build();
+
+        var provider1 = KeyStoreProvider.builder().keyStoreType(KeyStoreType.TRUST_STORE).key(keyHolder1).build();
+        var sameAsProvider1 = KeyStoreProvider.builder().keyStoreType(KeyStoreType.TRUST_STORE).key(keyHolder1)
+                .build();
+        var provider2 = KeyStoreProvider.builder().keyStoreType(KeyStoreType.TRUST_STORE).key(keyHolder2).build();
+
+        assertEquals(provider1, sameAsProvider1);
+        assertEquals(provider1.hashCode(), sameAsProvider1.hashCode());
+        assertNotEquals(provider1, provider2);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Cluster F of the project-analysis fix series (findings catalog: `doc/analysis-findings.md`, IDs NET-1..NET-10, SSL-1..SSL-4).

- **NET-1**: `UrlParameter.createNameValueString(true)` double-encoded already-encoded stored fields (`"b c"` → `b%2Bc`). The parameter now tracks whether its fields were stored encoded and only encodes on demand; the `encode=false` path is unchanged, and equality/toString semantics are pinned to name/value as before.
- **NET-2**: `fromQueryString` dropped every parameter whose value contains a literal `=` (Base64 values, nested URLs) and misparsed `"=foo"` as a parameter named `foo`. Pairs now split on the first `=` only; empty-name pairs are skipped.
- **NET-3/NET-4**: `createParameterString` no longer NPEs on null elements after the first position (all nulls are skipped consistently); `createParameterMap` docs now describe the empty-list case for null-valued parameters.
- **NET-5**: `UrlHelper.isValidUri(null/"")` returned `true`, contradicting its own javadoc and `tryParseUri`. Now `false`.
- **NET-6/NET-7**: `ParameterFilter`'s faces exclusion only matched `javax.faces` — Jakarta Faces (`jakarta.faces.ViewState` etc.) passed through unfiltered. Both prefixes are filtered now, and the comparison uses `Locale.ROOT` (Turkish-locale safe).
- **NET-8/NET-9**: `IDNInternetAddress` capped every address segment at 64 chars, silently skipping IDN conversion for valid addresses with longer domains (RFC 5321 allows 255). Local part stays at 64; constant-true `matcher.groupCount()` conditions removed.
- **SSL-1**: `KeyStoreProvider` loaded embedded keystores with the *provider's* `storePassword`, while `KeyHolderType.KEY_STORE`/`KeyMaterialHolder` document the holder's `keyPassword` as the store password. The holder's password now wins, falling back to the provider's.
- **SSL-2**: the documented "file location is ignored when key material is present" rule now actually holds — the location readability check only runs on the file-path branch; `@return` documents `Optional.empty()`.
- **SSL-3**: `KeyMaterialHolder` equality excluded `keyMaterial`, so holders carrying *different keys* compared equal and `Set` deduplication could silently drop key material. `keyMaterial` is now part of equals/hashCode (still excluded from `toString`); `KeyStoreProvider` equality includes its keys.
- **NET-10/SSL-4 (tests)**: encoding round-trips for both construction modes, `jakarta.faces` filtering, >64-char-domain IDN round-trip, sanitizer overloads and fallback path, keystore password precedence, `getKeyOrStorePassword()` combinations.

## Test plan

- `./mvnw clean install` — BUILD SUCCESS, 810 tests, 0 failures/errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKzn4Upj33uRFvWQep3UzE

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKzn4Upj33uRFvWQep3UzE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of email-style addresses, supporting longer domains/display names and safer IDN conversion, including sanitizer callbacks.
  * URL query parameter handling now avoids double-encoding and correctly parses values containing `=`.

* **Bug Fixes**
  * URI validation now returns `false` for `null`/empty input.
  * Face-related parameter filtering now consistently supports both `javax.faces` and `jakarta.faces`.

* **Behavior Changes**
  * Keystore loading prefers in-memory key material and uses the correct password for embedded stores.

* **Tests/Quality**
  * Expanded coverage for address parsing, parameter encoding/parsing, and keystore/equality semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->