### PR TITLE
base/lang/codec/concurrent: fix locale contract, capacity overflow, doc drift

### DIFF
--- a/src/main/java/de/cuioss/tools/base/Preconditions.java
+++ b/src/main/java/de/cuioss/tools/base/Preconditions.java
@@ -236,7 +236,8 @@ public class Preconditions {
      * @param errorMessageArgs     the arguments to be substituted into the message
      *                            template. Arguments are converted to strings
      *                            using {@link String#valueOf(Object)}. May be null
-     *                            or empty, but elements may not be null.
+     *                            or empty; {@code null} elements are formatted
+     *                            as {@code "null"}.
      * @throws IllegalArgumentException if {@code expression} is false
      * @see <a href="https://github.com/google/guava/blob/master/guava/src/com/google/common/base/Preconditions.java">Google Guava</a>
      * @since 1.0
@@ -329,7 +330,8 @@ public class Preconditions {
      * @param errorMessageArgs     the arguments to be substituted into the message
      *                            template. Arguments are converted to strings
      *                            using {@link String#valueOf(Object)}. May be null
-     *                            or empty, but elements may not be null.
+     *                            or empty; {@code null} elements are formatted
+     *                            as {@code "null"}.
      * @throws IllegalStateException if {@code expression} is false
      * @see <a href="https://github.com/google/guava/blob/master/guava/src/com/google/common/base/Preconditions.java">Google Guava</a>
      * @since 1.0

--- a/src/main/java/de/cuioss/tools/codec/Hex.java
+++ b/src/main/java/de/cuioss/tools/codec/Hex.java
@@ -98,7 +98,7 @@ import java.nio.charset.StandardCharsets;
  *   <li>Invalid hex strings throw {@link DecoderException}</li>
  *   <li>Odd-length hex strings throw {@link DecoderException}</li>
  *   <li>Invalid character encodings throw {@link java.nio.charset.UnsupportedCharsetException}</li>
- *   <li>Null inputs throw {@link IllegalArgumentException}</li>
+ *   <li>Null inputs throw {@link NullPointerException}</li>
  * </ul>
  *
  * <h2>Migration Notes</h2>
@@ -322,7 +322,7 @@ public class Hex {
      * @param data        a byte[] to convert to Hex characters
      * @param toLowerCase {@code true} converts to lowercase, {@code false} to
      *                    uppercase
-     * @return A String containing lower-case hexadecimal characters
+     * @return A String containing hexadecimal characters in the selected case
      */
     public static String encodeHexString(final byte[] data, final boolean toLowerCase) {
         return new String(encodeHex(data, toLowerCase));
@@ -360,7 +360,7 @@ public class Hex {
      * @param data        a byte buffer to convert to Hex characters
      * @param toLowerCase {@code true} converts to lowercase, {@code false} to
      *                    uppercase
-     * @return A String containing lower-case hexadecimal characters
+     * @return A String containing hexadecimal characters in the selected case
      */
     public static String encodeHexString(final ByteBuffer data, final boolean toLowerCase) {
         return new String(encodeHex(data, toLowerCase));
@@ -447,7 +447,7 @@ public class Hex {
      *
      * @param object String to convert to byte array
      * @return the byte array
-     * @throws IllegalArgumentException if the parameter is null
+     * @throws NullPointerException if the parameter is null
      */
     public byte[] decode(final byte[] object) throws DecoderException {
         return decodeHex(new String(object, getCharset()).toCharArray());
@@ -459,7 +459,7 @@ public class Hex {
      *
      * @param object String to convert to byte array
      * @return the byte array
-     * @throws IllegalArgumentException if the parameter is null
+     * @throws NullPointerException if the parameter is null
      */
     public byte[] decode(final ByteBuffer object) throws DecoderException {
         return decodeHex(new String(toByteArray(object), getCharset()).toCharArray());
@@ -523,7 +523,7 @@ public class Hex {
      *
      * @param array the byte buffer to convert
      * @return the byte array
-     * @throws IllegalArgumentException if the parameter is null
+     * @throws NullPointerException if the parameter is null
      */
     public byte[] encode(final ByteBuffer array) {
         return encodeHexString(array).getBytes(getCharset());

--- a/src/main/java/de/cuioss/tools/codec/package-info.java
+++ b/src/main/java/de/cuioss/tools/codec/package-info.java
@@ -47,14 +47,14 @@
  * <h2>Usage Examples</h2>
  * <h3>Basic Hex Encoding/Decoding</h3>
  * <pre>
- * // Encoding bytes to hex string (uppercase)
+ * // Encoding bytes to hex string (uppercase; false = uppercase, true = lowercase)
  * byte[] bytes = "Hello, World!".getBytes(StandardCharsets.UTF_8);
- * String hexString = Hex.encodeToString(bytes, true);
+ * String hexString = Hex.encodeHexString(bytes, false);
  * // Result: "48656C6C6F2C20576F726C6421"
  *
  * // Decoding hex string back to bytes
  * try {
- *     byte[] decoded = Hex.decode(hexString);
+ *     byte[] decoded = Hex.decodeHex(hexString);
  *     String original = new String(decoded, StandardCharsets.UTF_8);
  *     // Result: "Hello, World!"
  * } catch (DecoderException e) {
@@ -70,7 +70,7 @@
  *
  * // Decoding with custom charset
  * Hex decoder = new Hex(StandardCharsets.UTF_8);
- * byte[] result = decoder.decode(hex);
+ * byte[] result = decoder.decode(hex.getBytes(StandardCharsets.UTF_8));
  * </pre>
  *
  * <h2>Performance Considerations</h2>
@@ -110,7 +110,7 @@
  * byte[] data = DatatypeConverter.parseHexBinary(hex);
  *
  * // CUI Java Tools equivalent
- * String hex = de.cuioss.tools.codec.Hex.encodeHexString(bytes, true); // true for uppercase
+ * String hex = de.cuioss.tools.codec.Hex.encodeHexString(bytes, false); // false = uppercase
  * byte[] data = de.cuioss.tools.codec.Hex.decodeHex(hex);
  * </pre>
  *

--- a/src/main/java/de/cuioss/tools/concurrent/RingBuffer.java
+++ b/src/main/java/de/cuioss/tools/concurrent/RingBuffer.java
@@ -58,6 +58,14 @@ public class RingBuffer {
     private static final CuiLogger LOGGER = new CuiLogger(RingBuffer.class);
 
     /**
+     * Maximum supported capacity (2^30).
+     * <p>
+     * This is the largest power of 2 that fits into a positive {@code int};
+     * larger values would overflow when rounding up to the next power of 2.
+     */
+    static final int MAX_CAPACITY = 1 << 30;
+
+    /**
      * Storage array for measurements.
      * Uses AtomicLongArray to ensure thread-safe access and visibility.
      */
@@ -90,8 +98,8 @@ public class RingBuffer {
      * The actual capacity will be rounded up to the next power of 2
      * for performance optimization.
      *
-     * @param capacity the desired capacity (must be positive)
-     * @throws IllegalArgumentException if capacity is not positive
+     * @param capacity the desired capacity (must be positive and must not exceed 2^30)
+     * @throws IllegalArgumentException if capacity is not positive or exceeds 2^30
      */
     public RingBuffer(int capacity) {
         this(capacity, TimeUnit.MICROSECONDS);
@@ -103,14 +111,18 @@ public class RingBuffer {
      * The actual capacity will be rounded up to the next power of 2
      * for performance optimization.
      *
-     * @param capacity the desired capacity (must be positive)
+     * @param capacity the desired capacity (must be positive and must not exceed 2^30)
      * @param timeUnit the time unit for measurement values (must not be null)
-     * @throws IllegalArgumentException if capacity is not positive
+     * @throws IllegalArgumentException if capacity is not positive or exceeds 2^30
      * @throws NullPointerException if timeUnit is null
      */
     public RingBuffer(int capacity, @NonNull TimeUnit timeUnit) {
         if (capacity <= 0) {
             throw new IllegalArgumentException("Capacity must be positive: " + capacity);
+        }
+        if (capacity > MAX_CAPACITY) {
+            throw new IllegalArgumentException(
+                    "Capacity must not exceed 2^30 (" + MAX_CAPACITY + "): " + capacity);
         }
 
         int actualCapacity = nextPowerOfTwo(capacity);
@@ -149,11 +161,11 @@ public class RingBuffer {
     /**
      * Gets current statistics from this ring buffer.
      * <p>
-     * This method provides comprehensive statistics including sample count,
-     * average, P95, and P99. The result is eventually consistent and may
-     * include partial updates during concurrent write operations.
+     * This method provides comprehensive statistics including sample count
+     * and the P50 (median), P95, and P99 percentiles. The result is eventually
+     * consistent and may include partial updates during concurrent write operations.
      *
-     * @return immutable statistics snapshot containing sampleCount, average, p95, and p99
+     * @return immutable statistics snapshot containing sampleCount, p50, p95, and p99
      */
     public RingBufferStatistics getStatistics() {
         long[] snapshot = getSamplesSnapshot();

--- a/src/main/java/de/cuioss/tools/concurrent/RingBuffer.java
+++ b/src/main/java/de/cuioss/tools/concurrent/RingBuffer.java
@@ -63,7 +63,7 @@ public class RingBuffer {
      * This is the largest power of 2 that fits into a positive {@code int};
      * larger values would overflow when rounding up to the next power of 2.
      */
-    static final int MAX_CAPACITY = 1 << 30;
+    public static final int MAX_CAPACITY = 1 << 30;
 
     /**
      * Storage array for measurements.

--- a/src/main/java/de/cuioss/tools/concurrent/RingBufferStatistics.java
+++ b/src/main/java/de/cuioss/tools/concurrent/RingBufferStatistics.java
@@ -22,8 +22,8 @@ import java.util.concurrent.TimeUnit;
 /**
  * Immutable statistics snapshot from a ring buffer.
  * <p>
- * This record provides comprehensive statistics including sample count,
- * average, and key percentiles (P95, P99). All values are computed at
+ * This record provides comprehensive statistics including sample count
+ * and key percentiles (P50/median, P95, P99). All values are computed at
  * the time of creation and remain constant for the lifetime of the instance.
  * <p>
  * The implementation supports two creation patterns:

--- a/src/main/java/de/cuioss/tools/concurrent/StripedRingBuffer.java
+++ b/src/main/java/de/cuioss/tools/concurrent/StripedRingBuffer.java
@@ -84,6 +84,12 @@ public class StripedRingBuffer {
      * <p>
      * The window size will be distributed across all stripes. For example,
      * with 8 stripes and window size 100, each stripe will have capacity ~12.
+     * <p>
+     * <strong>Per-stripe retention:</strong> Each thread always writes to a single
+     * stripe (selected by its thread hash). Because a stripe only retains roughly
+     * {@code windowSize / stripeCount} samples, a single-threaded writer will
+     * retain only about that fraction of {@code windowSize} — the full window is
+     * only reached when writing threads are spread across all stripes.
      *
      * @param windowSize total number of samples to maintain across all stripes (must be positive)
      * @throws IllegalArgumentException if windowSize is not positive
@@ -97,6 +103,12 @@ public class StripedRingBuffer {
      * <p>
      * The window size will be distributed across all stripes. For example,
      * with 8 stripes and window size 100, each stripe will have capacity ~12.
+     * <p>
+     * <strong>Per-stripe retention:</strong> Each thread always writes to a single
+     * stripe (selected by its thread hash). Because a stripe only retains roughly
+     * {@code windowSize / stripeCount} samples, a single-threaded writer will
+     * retain only about that fraction of {@code windowSize} — the full window is
+     * only reached when writing threads are spread across all stripes.
      *
      * @param windowSize total number of samples to maintain across all stripes (must be positive)
      * @param timeUnit the time unit for measurement values (must not be null)
@@ -118,7 +130,8 @@ public class StripedRingBuffer {
             stripes[i] = new RingBuffer(sizePerStripe, timeUnit);
         }
 
-        int actualTotalCapacity = sizePerStripe * stripeCount;
+        // Each RingBuffer rounds its capacity up to the next power of 2
+        int actualTotalCapacity = nextPowerOfTwo(sizePerStripe) * stripeCount;
         if (actualTotalCapacity != windowSize) {
             LOGGER.debug("Striped ring buffer capacity adjusted from %s to %s (distributed across %s stripes)",
                     windowSize, actualTotalCapacity, stripeCount);
@@ -150,9 +163,10 @@ public class StripedRingBuffer {
     /**
      * Gets comprehensive statistics from all measurements across all stripes.
      * <p>
-     * This method computes a complete statistics snapshot including sample count,
-     * average, P95, and P99 in a single optimized pass. The result is eventually
-     * consistent and may include partial updates during concurrent write operations.
+     * This method computes a complete statistics snapshot including sample count
+     * and the P50 (median), P95, and P99 percentiles in a single optimized pass.
+     * The result is eventually consistent and may include partial updates during
+     * concurrent write operations.
      * <p>
      * The implementation is optimized for runtime performance by:
      * <ul>
@@ -162,7 +176,7 @@ public class StripedRingBuffer {
      *   <li>Avoiding boxing/unboxing overhead</li>
      * </ul>
      *
-     * @return immutable statistics snapshot containing sampleCount, average, p95, and p99
+     * @return immutable statistics snapshot containing sampleCount, p50, p95, and p99
      */
     public StripedRingBufferStatistics getStatistics() {
         return StripedRingBufferStatistics.computeFrom(stripes, timeUnit);

--- a/src/main/java/de/cuioss/tools/concurrent/StripedRingBuffer.java
+++ b/src/main/java/de/cuioss/tools/concurrent/StripedRingBuffer.java
@@ -130,8 +130,10 @@ public class StripedRingBuffer {
             stripes[i] = new RingBuffer(sizePerStripe, timeUnit);
         }
 
-        // Each RingBuffer rounds its capacity up to the next power of 2
-        int actualTotalCapacity = nextPowerOfTwo(sizePerStripe) * stripeCount;
+        // Each RingBuffer rounds its capacity up to the next power of 2. Computed in
+        // long: the total across stripes may exceed Integer.MAX_VALUE even though
+        // every single stripe is within RingBuffer's capacity limit.
+        long actualTotalCapacity = (long) nextPowerOfTwo(sizePerStripe) * stripeCount;
         if (actualTotalCapacity != windowSize) {
             LOGGER.debug("Striped ring buffer capacity adjusted from %s to %s (distributed across %s stripes)",
                     windowSize, actualTotalCapacity, stripeCount);

--- a/src/main/java/de/cuioss/tools/concurrent/package-info.java
+++ b/src/main/java/de/cuioss/tools/concurrent/package-info.java
@@ -35,7 +35,6 @@
  *     <ul>
  *       <li>{@link de.cuioss.tools.concurrent.StopWatch} - Time measurement utility</li>
  *       <li>Precise elapsed time tracking</li>
- *       <li>Support for split times</li>
  *     </ul>
  *   </li>
  * </ul>
@@ -43,16 +42,16 @@
  * <h2>Usage Examples</h2>
  * <pre>
  * // Using StopWatch for performance measurement
- * StopWatch watch = new StopWatch();
+ * StopWatch watch = StopWatch.createStarted();
  * try {
  *     // Perform operation
  *     someOperation();
  *
  *     LOGGER.info("Operation completed in %s ms",
- *         watch.getElapsedMilliseconds());
+ *         watch.elapsed(TimeUnit.MILLISECONDS));
  * } catch (Exception e) {
  *     LOGGER.error(e, "Operation failed after %s ms",
- *         watch.getElapsedMilliseconds());
+ *         watch.elapsed(TimeUnit.MILLISECONDS));
  *     throw e;
  * }
  *

--- a/src/main/java/de/cuioss/tools/lang/LocaleUtils.java
+++ b/src/main/java/de/cuioss/tools/lang/LocaleUtils.java
@@ -18,6 +18,7 @@ package de.cuioss.tools.lang;
 import de.cuioss.tools.base.Preconditions;
 import lombok.experimental.UtilityClass;
 
+import java.util.IllformedLocaleException;
 import java.util.Locale;
 
 /**
@@ -49,23 +50,25 @@ public class LocaleUtils {
      * </p>
      *
      * <pre>
-     *   LocaleUtils.toLocale("")           = new Locale("", "")
-     *   LocaleUtils.toLocale("en")         = new Locale("en", "")
-     *   LocaleUtils.toLocale("en_GB")      = new Locale("en", "GB")
-     *   LocaleUtils.toLocale("en_GB_xxx")  = new Locale("en", "GB", "xxx")   (#)
+     *   LocaleUtils.toLocale("")             = new Locale("", "")
+     *   LocaleUtils.toLocale("en")           = new Locale("en", "")
+     *   LocaleUtils.toLocale("en_GB")        = new Locale("en", "GB")
+     *   LocaleUtils.toLocale("en_GB_POSIX")  = new Locale("en", "GB", "POSIX")
      * </pre>
      *
      * <p>
      * This method validates the input strictly. The language code must be
      * lowercase. The country code must be uppercase. The separator must be an
-     * underscore. The length must be correct.
+     * underscore. The length must be correct. Each variant subtag must consist of
+     * 5-8 alphanumeric characters; multiple variant subtags may be separated by
+     * underscores (e.g. {@code "en_GB_POSIX_LINUX"}).
      * </p>
      *
      * <p>
-     * Note: This implementation uses the deprecated {@link Locale} constructor for
-     * backward compatibility with existing code that relies on its more lenient
-     * validation rules, particularly for variants. Future versions may migrate to
-     * {@link Locale.Builder} which enforces stricter rules.
+     * Note: This implementation is based on the strict {@link Locale.Builder}. Any
+     * {@link java.util.IllformedLocaleException} raised by the builder is
+     * translated to an {@link IllegalArgumentException} to keep the documented
+     * contract of this method.
      * </p>
      *
      * @param str the locale String to convert, null returns null
@@ -77,7 +80,11 @@ public class LocaleUtils {
         if (null == str) {
             return null;
         }
-        return toLocaleInternal(str);
+        try {
+            return toLocaleInternal(str);
+        } catch (final IllformedLocaleException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
     }
 
     private static Locale toLocaleInternal(final String str) {
@@ -94,13 +101,13 @@ public class LocaleUtils {
             return handleSimpleLocale(str);
         }
 
+        // Splitting a string that contains an underscore with limit 3 always
+        // yields two or three parts (trailing empty strings are retained).
         final var parts = str.split("_", 3);
-        return switch (parts.length) {
-            case 1 -> handleSinglePart(parts[0]);
-            case 2 -> handleTwoParts(parts[0], parts[1]);
-            case 3 -> handleThreeParts(str, parts);
-            default -> throw new IllegalArgumentException(INVALID_LOCALE_FORMAT + str);
-        };
+        if (parts.length == 2) {
+            return handleTwoParts(parts[0], parts[1]);
+        }
+        return handleThreeParts(str, parts);
     }
 
     private static Locale handleUnderscorePrefixedLocale(final String str) {
@@ -116,6 +123,7 @@ public class LocaleUtils {
         }
         if (parts.length == 3) {
             validateCountryCode(parts[1]);
+            validateVariant(parts[2]);
             return new Locale.Builder().setLanguage("").setRegion(parts[1]).setVariant(parts[2]).build();
         }
         throw new IllegalArgumentException(INVALID_LOCALE_FORMAT + str);
@@ -127,19 +135,12 @@ public class LocaleUtils {
         return new Locale.Builder().setLanguage(str).build();
     }
 
-    private static Locale handleSinglePart(final String language) {
-        return new Locale.Builder().setLanguage(language.toLowerCase()).build();
-    }
-
     private static Locale handleTwoParts(final String language, final String country) {
         validateLanguageCode(language);
         if (country.matches("\\d{3}")) {
             return new Locale.Builder().setLanguage(language).setRegion(country).build();
         }
         validateCountryCode(country);
-        if (language.isEmpty()) {
-            return new Locale.Builder().setLanguage("").setRegion(country).build();
-        }
         return new Locale.Builder().setLanguage(language).setRegion(country).build();
     }
 

--- a/src/main/java/de/cuioss/tools/lang/MoreObjects.java
+++ b/src/main/java/de/cuioss/tools/lang/MoreObjects.java
@@ -38,7 +38,7 @@ public class MoreObjects {
      *
      * @param <T>          defining the type to be returned.
      *
-     * @param underCheck   KeyStoreType to be checked / cast. If it is null or is
+     * @param underCheck   the object to be checked / cast. If it is null or is
      *                     not assignable to expectedType an
      *                     {@link IllegalArgumentException} will be thrown.
      * @param expectedType checks the type . If it is null an

--- a/src/main/java/de/cuioss/tools/lang/package-info.java
+++ b/src/main/java/de/cuioss/tools/lang/package-info.java
@@ -64,8 +64,7 @@
  *
  * // Locale handling
  * Locale locale = LocaleUtils.toLocale("en_US");
- * boolean isValid = LocaleUtils.isISO639LanguageCode("en");
- * // Result: true
+ * // Result: Locale with language "en" and country "US"
  *
  * // Type-safe operations
  * String str = MoreObjects.requireType(obj, String.class);

--- a/src/test/java/de/cuioss/tools/codec/HexTest.java
+++ b/src/test/java/de/cuioss/tools/codec/HexTest.java
@@ -157,8 +157,9 @@ class HexTest {
         void encodeReadOnlyByteBuffer() {
             final var bb = ByteBuffer.allocate(16);
             final var expected = Hex.encodeHexString(bb.array());
-            bb.asReadOnlyBuffer();
-            assertEquals(expected, Hex.encodeHexString(bb));
+            final var readOnly = bb.asReadOnlyBuffer();
+            assertEquals(expected, Hex.encodeHexString(readOnly));
+            assertEquals(0, readOnly.remaining(), "Buffer should be consumed");
         }
     }
 

--- a/src/test/java/de/cuioss/tools/concurrent/RingBufferTest.java
+++ b/src/test/java/de/cuioss/tools/concurrent/RingBufferTest.java
@@ -64,6 +64,13 @@ class RingBufferTest {
     }
 
     @Test
+    void shouldRejectCapacityAboveMaximum() {
+        // Capacities above 2^30 would overflow when rounding to the next power of 2
+        assertThrows(IllegalArgumentException.class, () -> new RingBuffer(RingBuffer.MAX_CAPACITY + 1));
+        assertThrows(IllegalArgumentException.class, () -> new RingBuffer(Integer.MAX_VALUE));
+    }
+
+    @Test
     void shouldRejectNegativeMeasurements() {
         RingBuffer buffer = new RingBuffer(10);
         assertThrows(IllegalArgumentException.class, () -> buffer.recordMeasurement(-1));

--- a/src/test/java/de/cuioss/tools/lang/LocaleUtilsTest.java
+++ b/src/test/java/de/cuioss/tools/lang/LocaleUtilsTest.java
@@ -155,4 +155,48 @@ class LocaleUtilsTest {
         assertTrue(locale.getCountry().isEmpty());
         assertEquals(variant, locale.getVariant());
     }
+
+    @ParameterizedTest
+    @CsvSource({
+            "en_GB_POSIX,POSIX",
+            "en_GB_POSIX123,POSIX123"
+    })
+    void shouldHandleVariantLengthBoundaries(String localeString, String variant) {
+        var locale = LocaleUtils.toLocale(localeString);
+        assertNotNull(locale, "Should create valid locale");
+        assertEquals("en", locale.getLanguage());
+        assertEquals("GB", locale.getCountry());
+        assertEquals(variant, locale.getVariant());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "en_GB_POSI",       // 4-char variant, below minimum of 5
+            "en_GB_POSIX1234"   // 9-char variant, above maximum of 8
+    })
+    void shouldRejectVariantsOutsideLengthBoundaries(String invalidLocale) {
+        assertThrows(IllegalArgumentException.class, () -> LocaleUtils.toLocale(invalidLocale),
+                "Variant must be 5-8 alphanumeric characters");
+    }
+
+    @Test
+    void shouldHandleUnderscoreSeparatedMultiVariant() {
+        var locale = LocaleUtils.toLocale("en_GB_POSIX_LINUX");
+        assertNotNull(locale, "Should create valid locale");
+        assertEquals("en", locale.getLanguage());
+        assertEquals("GB", locale.getCountry());
+        assertEquals("POSIX_LINUX", locale.getVariant());
+    }
+
+    @Test
+    void shouldRejectNumericLanguageCode() {
+        assertThrows(IllegalArgumentException.class, () -> LocaleUtils.toLocale("12"),
+                "Numeric language codes must be rejected with IllegalArgumentException");
+    }
+
+    @Test
+    void shouldRejectTooShortVariantAfterCountryOnly() {
+        assertThrows(IllegalArgumentException.class, () -> LocaleUtils.toLocale("_EN_v"),
+                "Variant must be validated on the underscore-prefixed path");
+    }
 }


### PR DESCRIPTION
## Summary

Cluster H of the project-analysis fix series (findings catalog: `doc/analysis-findings.md`, IDs LANG-1..LANG-7, CODEC-1..CODEC-4, CONC-1..CONC-4, BASE-1).

- **LANG-3**: `LocaleUtils.toLocale` documents `IllegalArgumentException`, but `IllformedLocaleException` (not an IAE subclass) escaped for inputs that pass the pre-checks — e.g. `toLocale("12")` and `toLocale("_EN_v")` (the underscore path skipped variant validation entirely). The underscore path now validates variants, and `IllformedLocaleException` is translated to the documented `IllegalArgumentException`.
- **LANG-1/LANG-2 (high javadoc)**: the class's own headline example (`toLocale("en_GB_xxx")`) threw at runtime — variants must be 5-8 alphanumeric chars; the "uses the deprecated lenient Locale constructor" implementation note described the exact opposite of the strict `Locale.Builder` code. Both corrected.
- **LANG-4**: removed unreachable branches (`case 1`/`default` after `split("_", 3)` on an underscore-containing string, dead `handleSinglePart`, dead empty-language branch).
- **CONC-2**: `RingBuffer` overflowed to `NegativeArraySizeException` for capacities above 2^30; now rejected with a documented `IllegalArgumentException` (`MAX_CAPACITY = 1 << 30`).
- **CONC-4**: `StripedRingBuffer.windowSize` claimed "total samples across all stripes" — but a single thread only ever writes one stripe, so a single-threaded writer retains only ~windowSize/stripeCount samples. Now documented explicitly; the adjusted-capacity debug log accounts for power-of-two rounding.
- **CODEC-1..CODEC-3**: codec package examples used nonexistent APIs (`Hex.encodeToString`, static `decode`) and inverted the `toLowerCase` semantics; `Hex` docs claimed IllegalArgumentException for null inputs (actual: NPE) and "lower-case" output regardless of the case parameter. All corrected.
- **CONC-1, LANG-5, LANG-6, BASE-1, CONC-3**: package/method docs fixed — non-compiling StopWatch example plus false "split times" claim, nonexistent `isISO639LanguageCode` example, "KeyStoreType" copy-paste in `MoreObjects`, wrong "elements may not be null" on `Preconditions` message args, nonexistent "average" in ring-buffer statistics docs.
- **LANG-7/CODEC-4 (tests)**: variant boundary tests (4/5/8/9 chars), multi-variant, numeric language codes; the read-only-ByteBuffer Hex test now actually encodes the read-only buffer (it previously discarded `asReadOnlyBuffer()`), plus capacity-limit tests.

## Test plan

- `./mvnw clean install` — BUILD SUCCESS, 804 tests, 0 failures/errors/skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKzn4Upj33uRFvWQep3UzE

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKzn4Upj33uRFvWQep3UzE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened locale parsing and validation for stricter, more predictable locale handling.
  * Added a clearer maximum capacity limit for ring buffers, with rejection of oversized values.

* **Documentation**
  * Improved API docs and examples across codec, concurrency, language, and precondition utilities.
  * Clarified null handling, exception types, and statistics output descriptions.

* **Tests**
  * Expanded coverage for locale parsing, hex encoding, and ring buffer capacity limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->