### PR TITLE
chore: apply pending OpenRewrite modernizations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/de/cuioss/tools/collect/CollectionLiterals.java
+++ b/src/main/java/de/cuioss/tools/collect/CollectionLiterals.java
@@ -214,7 +214,7 @@ public class CollectionLiterals {
      * @param <E> a E class
      */
     public static <E> List<E> immutableList() {
-        return Collections.emptyList();
+        return List.of();
     }
 
     /**
@@ -229,7 +229,7 @@ public class CollectionLiterals {
     @SafeVarargs
     public static <E> List<E> immutableList(E... elements) {
         if (isEmpty(elements)) {
-            return Collections.emptyList();
+            return List.of();
         }
         return Collections.unmodifiableList(mutableList(elements));
     }
@@ -245,7 +245,7 @@ public class CollectionLiterals {
      */
     public static <E> List<E> immutableList(E element) {
         if (null == element) {
-            return Collections.emptyList();
+            return List.of();
         }
         return List.of(element);
     }
@@ -261,7 +261,7 @@ public class CollectionLiterals {
      */
     public static <E> List<E> immutableList(Iterable<? extends E> elements) {
         if (isEmpty(elements)) {
-            return Collections.emptyList();
+            return List.of();
         }
         return Collections.unmodifiableList(mutableList(elements));
     }
@@ -278,7 +278,7 @@ public class CollectionLiterals {
      */
     public static <E> List<E> immutableList(Collection<? extends E> elements) {
         if (isEmpty(elements)) {
-            return Collections.emptyList();
+            return List.of();
         }
 
         return Collections.unmodifiableList(mutableList(elements));
@@ -295,7 +295,7 @@ public class CollectionLiterals {
      */
     public static <E> List<E> immutableList(Stream<? extends E> elements) {
         if (isEmpty(elements)) {
-            return Collections.emptyList();
+            return List.of();
         }
         return Collections.unmodifiableList(mutableList(elements));
     }
@@ -311,7 +311,7 @@ public class CollectionLiterals {
      */
     public static <E> List<E> immutableList(Iterator<? extends E> elements) {
         if (isEmpty(elements)) {
-            return Collections.emptyList();
+            return List.of();
         }
         return Collections.unmodifiableList(mutableList(elements));
     }
@@ -437,7 +437,7 @@ public class CollectionLiterals {
      * @param <E> a E class
      */
     public static <E> Set<E> immutableSet() {
-        return Collections.emptySet();
+        return Set.of();
     }
 
     /**
@@ -451,7 +451,7 @@ public class CollectionLiterals {
      */
     public static <E> Set<E> immutableSet(E element) {
         if (null == element) {
-            return Collections.emptySet();
+            return Set.of();
         }
         return Set.of(element);
     }
@@ -468,7 +468,7 @@ public class CollectionLiterals {
     @SafeVarargs
     public static <E> Set<E> immutableSet(E... elements) {
         if (isEmpty(elements)) {
-            return Collections.emptySet();
+            return Set.of();
         }
         return Collections.unmodifiableSet(mutableSet(elements));
     }
@@ -483,7 +483,7 @@ public class CollectionLiterals {
      */
     public static <E> Set<E> immutableSet(Iterable<? extends E> elements) {
         if (isEmpty(elements)) {
-            return Collections.emptySet();
+            return Set.of();
         }
         return Collections.unmodifiableSet(mutableSet(elements));
     }
@@ -499,7 +499,7 @@ public class CollectionLiterals {
      */
     public static <E> Set<E> immutableSet(Iterator<? extends E> elements) {
         if (isEmpty(elements)) {
-            return Collections.emptySet();
+            return Set.of();
         }
         return Collections.unmodifiableSet(mutableSet(elements));
     }
@@ -515,7 +515,7 @@ public class CollectionLiterals {
      */
     public static <E> Set<E> immutableSet(Stream<? extends E> elements) {
         if (isEmpty(elements)) {
-            return Collections.emptySet();
+            return Set.of();
         }
         return Collections.unmodifiableSet(mutableSet(elements));
     }
@@ -802,7 +802,7 @@ public class CollectionLiterals {
      * @param <V> a V class
      */
     public static <K, V> Map<K, V> immutableMap() {
-        return Collections.emptyMap();
+        return Map.of();
     }
 
     /**
@@ -819,7 +819,7 @@ public class CollectionLiterals {
      */
     public static <K, V> Map<K, V> immutableMap(Map<K, V> source) {
         if (null == source) {
-            return Collections.emptyMap();
+            return Map.of();
         }
         return copyToUnmodifiableMap(source);
     }

--- a/src/main/java/de/cuioss/tools/collect/PartialArrayList.java
+++ b/src/main/java/de/cuioss/tools/collect/PartialArrayList.java
@@ -22,7 +22,6 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -70,7 +69,7 @@ public class PartialArrayList<T extends Serializable> extends ArrayList<T> imple
      * @return an empty {@link PartialArrayList}.
      */
     public static <T extends Serializable> PartialArrayList<T> emptyList() {
-        return new PartialArrayList<>(Collections.emptyList(), false);
+        return new PartialArrayList<>(List.of(), false);
     }
 
     /**

--- a/src/main/java/de/cuioss/tools/net/IDNInternetAddress.java
+++ b/src/main/java/de/cuioss/tools/net/IDNInternetAddress.java
@@ -15,10 +15,9 @@
  */
 package de.cuioss.tools.net;
 
+import de.cuioss.tools.logging.CuiLogger;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
-
-import de.cuioss.tools.logging.CuiLogger;
 
 import java.net.IDN;
 import java.util.function.UnaryOperator;

--- a/src/main/java/de/cuioss/tools/net/UrlHelper.java
+++ b/src/main/java/de/cuioss/tools/net/UrlHelper.java
@@ -22,7 +22,6 @@ import lombok.experimental.UtilityClass;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -103,7 +102,7 @@ public final class UrlHelper {
      */
     public static List<String> splitPath(String pathString) {
         if (isEmpty(pathString)) {
-            return Collections.emptyList();
+            return List.of();
         }
         return Splitter.on(Pattern.compile("/")).trimResults().omitEmptyStrings().splitToList(pathString);
     }
@@ -117,7 +116,7 @@ public final class UrlHelper {
      */
     public static List<String> splitHost(String host) {
         if (isEmpty(host)) {
-            return Collections.emptyList();
+            return List.of();
         }
         return Splitter.on(Pattern.compile("\\.")).trimResults().omitEmptyStrings().splitToList(host);
     }

--- a/src/main/java/de/cuioss/tools/net/UrlParameter.java
+++ b/src/main/java/de/cuioss/tools/net/UrlParameter.java
@@ -172,7 +172,7 @@ public class UrlParameter implements Serializable, Comparable<UrlParameter> {
     public static List<UrlParameter> getUrlParameterFromMap(final Map<String, List<String>> map,
             final ParameterFilter parameterFilter, final boolean encode) {
         if (MoreCollections.isEmpty(map)) {
-            return Collections.emptyList();
+            return List.of();
         }
         final List<UrlParameter> extracted = new ArrayList<>();
         for (final Entry<String, List<String>> entry : map.entrySet()) {
@@ -204,7 +204,7 @@ public class UrlParameter implements Serializable, Comparable<UrlParameter> {
     public static List<UrlParameter> filterParameter(final List<UrlParameter> toBeFiltered,
             final ParameterFilter parameterFilter) {
         if (toBeFiltered == null || toBeFiltered.isEmpty()) {
-            return Collections.emptyList();
+            return List.of();
         }
         final var filtered = new ArrayList<UrlParameter>();
         for (final UrlParameter parameter : toBeFiltered) {
@@ -249,7 +249,7 @@ public class UrlParameter implements Serializable, Comparable<UrlParameter> {
     public static List<UrlParameter> fromQueryString(String queryString) {
         LOGGER.trace("Parsing Query String %s", queryString);
         if (MoreStrings.isEmpty(queryString)) {
-            return Collections.emptyList();
+            return List.of();
         }
         var cleaned = queryString.trim();
         if (cleaned.startsWith("?")) {
@@ -257,7 +257,7 @@ public class UrlParameter implements Serializable, Comparable<UrlParameter> {
         }
         if (MoreStrings.isEmpty(cleaned)) {
             LOGGER.debug("Given String solely consists of '?' symbol, ignoring");
-            return Collections.emptyList();
+            return List.of();
         }
         var elements = Splitter.on(Pattern.compile("&")).trimResults().omitEmptyStrings().splitToList(cleaned);
         var builder = new CollectionBuilder<UrlParameter>();

--- a/src/main/java/de/cuioss/tools/reflect/MoreReflection.java
+++ b/src/main/java/de/cuioss/tools/reflect/MoreReflection.java
@@ -373,7 +373,7 @@ public final class MoreReflection {
     public static <A extends Annotation> List<A> extractAllAnnotations(final Class<?> annotatedType,
             final Class<A> annotation) {
         if (null == annotatedType || Object.class.equals(annotatedType)) {
-            return Collections.emptyList();
+            return List.of();
         }
 
         final var builder = new CollectionBuilder<A>();

--- a/src/main/java/de/cuioss/tools/string/Joiner.java
+++ b/src/main/java/de/cuioss/tools/string/Joiner.java
@@ -204,14 +204,14 @@ public final class Joiner {
         }
         var builder = new ArrayList<CharSequence>();
         for (Object element : parts) {
-            if (null == element) {
-                if (!joinerConfig.isSkipNulls()) {
-                    builder.add(joinerConfig.getUseForNull());
+            switch (element) {
+                case null -> {
+                    if (!joinerConfig.isSkipNulls()) {
+                        builder.add(joinerConfig.getUseForNull());
+                    }
                 }
-            } else if (element instanceof CharSequence sequence) {
-                builder.add(sequence);
-            } else {
-                builder.add(MoreStrings.lenientToString(element));
+                case CharSequence sequence -> builder.add(sequence);
+                default -> builder.add(MoreStrings.lenientToString(element));
             }
         }
         if (joinerConfig.isSkipEmpty()) {

--- a/src/main/java/de/cuioss/tools/string/Splitter.java
+++ b/src/main/java/de/cuioss/tools/string/Splitter.java
@@ -21,7 +21,6 @@ import lombok.AccessLevel;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -315,11 +314,11 @@ public final class Splitter {
     @NonNull
     public List<String> splitToList(String sequence) {
         if (null == sequence) {
-            return Collections.emptyList();
+            return List.of();
         }
         LOGGER.debug("Splitting '%s' with pattern '%s'", sequence, splitterConfig.getSeparator());
         if (isEmpty(sequence)) {
-            return Collections.emptyList();
+            return List.of();
         }
 
         var pattern = splitterConfig.getPattern();
@@ -332,7 +331,7 @@ public final class Splitter {
         var splitted = pattern.split(sequence, splitterConfig.getMaxItems());
         if (0 == splitted.length) {
             LOGGER.trace("No content to be returned for input %s and configuration %s", sequence, splitterConfig);
-            return Collections.emptyList();
+            return List.of();
         }
 
         var builder = new CollectionBuilder<String>();

--- a/src/test/java/de/cuioss/tools/codec/HexTest.java
+++ b/src/test/java/de/cuioss/tools/codec/HexTest.java
@@ -97,13 +97,13 @@ class HexTest {
 
         @Test
         @DisplayName("handle empty byte array")
-        void decodeByteArrayEmpty() throws DecoderException {
+        void decodeByteArrayEmpty() throws Exception {
             assertArrayEquals(new byte[0], new Hex().decode(new byte[0]));
         }
 
         @Test
         @DisplayName("handle empty byte buffer")
-        void decodeByteBufferEmpty() throws DecoderException {
+        void decodeByteBufferEmpty() throws Exception {
             assertArrayEquals(new byte[0], new Hex().decode(ByteBuffer.allocate(0)));
         }
 
@@ -169,7 +169,7 @@ class HexTest {
 
         @Test
         @DisplayName("decode hex string correctly")
-        void decodeHexString() throws DecoderException {
+        void decodeHexString() throws Exception {
             final var input = "48656c6c6f20576f726c64";
             final var expected = "Hello World".getBytes(StandardCharsets.UTF_8);
             assertArrayEquals(expected, Hex.decodeHex(input));
@@ -177,7 +177,7 @@ class HexTest {
 
         @Test
         @DisplayName("decode hex char array correctly")
-        void decodeHexCharArray() throws DecoderException {
+        void decodeHexCharArray() throws Exception {
             final var input = "48656c6c6f20576f726c64".toCharArray();
             final var expected = "Hello World".getBytes(StandardCharsets.UTF_8);
             assertArrayEquals(expected, Hex.decodeHex(input));
@@ -287,7 +287,7 @@ class HexTest {
 
         @Test
         @DisplayName("handle empty inputs")
-        void handleEmptyInputs() throws DecoderException {
+        void handleEmptyInputs() throws Exception {
             // Empty string decode
             assertArrayEquals(new byte[0], Hex.decodeHex(""));
             assertArrayEquals(new byte[0], Hex.decodeHex(new char[0]));
@@ -332,7 +332,7 @@ class HexTest {
 
         @Test
         @DisplayName("correctly encode and decode random data")
-        void roundTripRandom() throws DecoderException {
+        void roundTripRandom() throws Exception {
             final var hex = new Hex();
             final var random = new Random();
 
@@ -350,7 +350,7 @@ class HexTest {
 
         @Test
         @DisplayName("correctly handle case sensitivity")
-        void roundTripCaseSensitivity() throws DecoderException {
+        void roundTripCaseSensitivity() throws Exception {
             final var hex = new Hex();
             final var data = "Hello World".getBytes(StandardCharsets.UTF_8);
 

--- a/src/test/java/de/cuioss/tools/collect/MoreCollectionsTest.java
+++ b/src/test/java/de/cuioss/tools/collect/MoreCollectionsTest.java
@@ -37,7 +37,7 @@ class MoreCollectionsTest {
     void shouldDetermineEmptinessForVarags() {
         assertFalse(isEmpty("1"));
         assertFalse(isEmpty("1", "2"));
-        assertTrue(isEmpty(Collections.emptyList().toArray()));
+        assertTrue(isEmpty(List.of().toArray()));
         assertTrue(isEmpty((Object[]) null));
 
         requireNotEmpty("1");
@@ -52,12 +52,12 @@ class MoreCollectionsTest {
     void shouldDetermineEmptinessForIterable() {
         assertFalse(isEmpty((Iterable<?>) mutableList("1")));
         assertFalse(isEmpty((Iterable<?>) mutableList("1", "2")));
-        assertTrue(isEmpty((Iterable<?>) Collections.emptyList()));
+        assertTrue(isEmpty((Iterable<?>) List.of()));
         assertTrue(isEmpty((Iterable<?>) null));
 
         requireNotEmpty((Iterable<String>) mutableList("1"));
         requireNotEmpty((Iterable<String>) mutableList("1"), MESSAGE);
-        Iterable<String> emptyIterable = Collections.emptyList();
+        Iterable<String> emptyIterable = List.of();
         assertThrows(IllegalArgumentException.class, () ->
                 requireNotEmpty(emptyIterable));
 
@@ -69,12 +69,12 @@ class MoreCollectionsTest {
     void shouldDetermineEmptinessForCollection() {
         assertFalse(isEmpty(mutableList("1")));
         assertFalse(isEmpty(mutableList("1", "2")));
-        assertTrue(isEmpty(Collections.emptyList()));
+        assertTrue(isEmpty(List.of()));
         assertTrue(isEmpty((Collection<?>) null));
 
         requireNotEmpty(mutableList("1"));
         requireNotEmpty(mutableList("1"), MESSAGE);
-        List<String> emptyList = Collections.emptyList();
+        List<String> emptyList = List.of();
         assertThrows(IllegalArgumentException.class, () ->
                 requireNotEmpty(emptyList));
 
@@ -116,7 +116,7 @@ class MoreCollectionsTest {
     @Test
     void shouldDetermineEmptinessForStream() {
         assertFalse(isEmpty(mutableList("1").stream()));
-        assertFalse(isEmpty(Collections.emptyList().stream()));
+        assertFalse(isEmpty(List.of().stream()));
         assertTrue(isEmpty((Stream<?>) null));
 
         requireNotEmpty(mutableList("1").stream());
@@ -135,7 +135,7 @@ class MoreCollectionsTest {
         Map<String, String> map = immutableMap(key, value);
 
         assertFalse(containsKey(null, key));
-        assertFalse(containsKey(Collections.emptyMap(), key));
+        assertFalse(containsKey(Map.of(), key));
 
         assertFalse(containsKey(map));
         assertFalse(containsKey(map, (Object[]) null));
@@ -241,7 +241,7 @@ class MoreCollectionsTest {
                 diff.entriesDiffering()).hashCode(), diff.hashCode());
 
         assertNotEquals(diff, otherDiff);
-        assertNotEquals(diff, "someString");
+        assertNotEquals("someString", diff);
         assertNotEquals(null, diff);
     }
 
@@ -261,7 +261,7 @@ class MoreCollectionsTest {
         assertEquals(Arrays.asList("value1", "value2").hashCode(), difference.hashCode());
 
         assertNotEquals(difference, otherDifference);
-        assertNotEquals(difference, "someString");
+        assertNotEquals("someString", difference);
         assertNotEquals(null, difference);
         assertNotNull(difference.toString());
     }

--- a/src/test/java/de/cuioss/tools/collect/PartialArrayListTest.java
+++ b/src/test/java/de/cuioss/tools/collect/PartialArrayListTest.java
@@ -21,7 +21,6 @@ import de.cuioss.tools.support.ObjectMethodsAsserts;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static de.cuioss.tools.collect.PartialArrayList.emptyList;
@@ -47,8 +46,8 @@ class PartialArrayListTest {
         assertFalse(emptyList().isMoreAvailable());
         assertTrue(of(null, DEFAULT_SIZE).isEmpty());
         assertFalse(of(null, DEFAULT_SIZE).isMoreAvailable());
-        assertTrue(of(Collections.emptyList(), DEFAULT_SIZE).isEmpty());
-        assertFalse(of(Collections.emptyList(), DEFAULT_SIZE).isMoreAvailable());
+        assertTrue(of(List.of(), DEFAULT_SIZE).isEmpty());
+        assertFalse(of(List.of(), DEFAULT_SIZE).isMoreAvailable());
     }
 
     @Test

--- a/src/test/java/de/cuioss/tools/concurrent/RingBufferTest.java
+++ b/src/test/java/de/cuioss/tools/concurrent/RingBufferTest.java
@@ -160,7 +160,7 @@ class RingBufferTest {
     }
 
     @Test
-    void shouldHandleConcurrentWrites() throws InterruptedException {
+    void shouldHandleConcurrentWrites() throws Exception {
         RingBuffer buffer = new RingBuffer(1000);
         int threadCount = 10;
         int measurementsPerThread = 1000;

--- a/src/test/java/de/cuioss/tools/concurrent/StripedRingBufferTest.java
+++ b/src/test/java/de/cuioss/tools/concurrent/StripedRingBufferTest.java
@@ -116,7 +116,7 @@ class StripedRingBufferTest {
     }
 
     @Test
-    void shouldHandleConcurrentAccess() throws InterruptedException {
+    void shouldHandleConcurrentAccess() throws Exception {
         StripedRingBuffer buffer = new StripedRingBuffer(1000);
         int threadCount = 20;
         int measurementsPerThread = 1000;

--- a/src/test/java/de/cuioss/tools/io/FileLoaderUtilityTest.java
+++ b/src/test/java/de/cuioss/tools/io/FileLoaderUtilityTest.java
@@ -17,7 +17,6 @@ package de.cuioss.tools.io;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
@@ -47,7 +46,7 @@ class FileLoaderUtilityTest {
     }
 
     @Test
-    void shouldCopyExistingFile() throws IOException {
+    void shouldCopyExistingFile() throws Exception {
         final var copy = copyFileToTemp(LOADER_EXISTING_FILE_CLASSPATH, true);
         assertNotNull(copy);
         assertTrue(Files.exists(copy));
@@ -81,7 +80,7 @@ class FileLoaderUtilityTest {
     }
 
     @Test
-    void shouldReturnContentAsString() throws IOException {
+    void shouldReturnContentAsString() throws Exception {
         var loaded = FileLoaderUtility.toString(LOADER_EXISTING_FILE_CLASSPATH);
         assertNotNull(loaded);
         assertFalse(loaded.isEmpty());
@@ -102,7 +101,7 @@ class FileLoaderUtilityTest {
     }
 
     @Test
-    void shouldReturnContentAsStringWithCharset() throws IOException {
+    void shouldReturnContentAsStringWithCharset() throws Exception {
         var loaded = FileLoaderUtility.toString(LOADER_EXISTING_FILE_CLASSPATH, StandardCharsets.UTF_8);
         assertNotNull(loaded);
         assertFalse(loaded.isEmpty());

--- a/src/test/java/de/cuioss/tools/io/FileSystemLoaderTest.java
+++ b/src/test/java/de/cuioss/tools/io/FileSystemLoaderTest.java
@@ -18,8 +18,6 @@ package de.cuioss.tools.io;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
-import java.io.IOException;
-import java.net.MalformedURLException;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -43,7 +41,7 @@ class FileSystemLoaderTest {
     private static final String NOT_EXISTING_FILE_PATH = Path.of(NOT_EXISTING_FILE).toAbsolutePath().toString();
 
     @Test
-    void shouldHandleExistingFile() throws IOException {
+    void shouldHandleExistingFile() throws Exception {
         final var loader = new FileSystemLoader(EXISTING_FILE_PATH);
         assertTrue(loader.isReadable());
         assertTrue(loader.isFilesystemLoader());
@@ -52,7 +50,7 @@ class FileSystemLoaderTest {
     }
 
     @Test
-    void shouldHandlePathAsArgument() throws IOException {
+    void shouldHandlePathAsArgument() throws Exception {
         final var loader = new FileSystemLoader(Path.of(EXISTING_FILE_PATH));
         assertTrue(loader.isReadable());
         assertTrue(loader.isFilesystemLoader());
@@ -61,7 +59,7 @@ class FileSystemLoaderTest {
     }
 
     @Test
-    void shouldHandleExistingExternalFile() throws IOException {
+    void shouldHandleExistingExternalFile() throws Exception {
         final var loader = new FileSystemLoader(EXISTING_EXTERNAL_FILE);
         assertTrue(loader.isReadable());
         assertTrue(loader.isFilesystemLoader());
@@ -70,7 +68,7 @@ class FileSystemLoaderTest {
     }
 
     @Test
-    void shouldHandleExternalFileWithoutLeadingSeparator() throws IOException {
+    void shouldHandleExternalFileWithoutLeadingSeparator() throws Exception {
         final var loader = new FileSystemLoader("external:" + EXISTING_FILE);
         assertTrue(loader.isReadable(), "external: paths without leading separator should resolve "
                 + "relative to the working directory");
@@ -124,7 +122,7 @@ class FileSystemLoaderTest {
     }
 
     @Test
-    void shouldHandleFilePrefixedPath() throws IOException {
+    void shouldHandleFilePrefixedPath() throws Exception {
         assertEquals(new File(EXISTING_FILE).getCanonicalPath(),
                 FileSystemLoader.checkPathName(FileTypePrefix.FILE + EXISTING_FILE));
     }
@@ -136,7 +134,7 @@ class FileSystemLoaderTest {
     }
 
     @Test
-    void shouldHandleOutputStreamForWritableFile() throws IOException {
+    void shouldHandleOutputStreamForWritableFile() throws Exception {
         // Create a temporary file for testing
         File tempFile = File.createTempFile("test", ".txt");
         tempFile.deleteOnExit();
@@ -165,7 +163,7 @@ class FileSystemLoaderTest {
     }
 
     @Test
-    void shouldGetUrlForExistingFile() throws IOException {
+    void shouldGetUrlForExistingFile() throws Exception {
         var loader = new FileSystemLoader(EXISTING_FILE_PATH);
         var url = loader.getURL();
         assertNotNull(url);
@@ -173,7 +171,7 @@ class FileSystemLoaderTest {
     }
 
     @Test
-    void shouldGetUrlForNonExistentFile() throws MalformedURLException {
+    void shouldGetUrlForNonExistentFile() throws Exception {
         var loader = new FileSystemLoader(NOT_EXISTING_FILE_PATH);
         var url = loader.getURL();
         assertNotNull(url);

--- a/src/test/java/de/cuioss/tools/io/IOStreamsCopyTest.java
+++ b/src/test/java/de/cuioss/tools/io/IOStreamsCopyTest.java
@@ -318,7 +318,7 @@ class IOStreamsCopyTest {
     }
 
     @Test
-    void copyLargeCharExtraLength() throws IOException {
+    void copyLargeCharExtraLength() throws Exception {
         // Create streams
         try (var is = new CharArrayReader(carr);
              var os = new CharArrayWriter()) {
@@ -337,7 +337,7 @@ class IOStreamsCopyTest {
     }
 
     @Test
-    void copyLargeCharFullLength() throws IOException {
+    void copyLargeCharFullLength() throws Exception {
         // Create streams
         try (var is = new CharArrayReader(carr);
              var os = new CharArrayWriter()) {
@@ -355,7 +355,7 @@ class IOStreamsCopyTest {
     }
 
     @Test
-    void copyLargeCharNoSkip() throws IOException {
+    void copyLargeCharNoSkip() throws Exception {
         // Create streams
         try (var is = new CharArrayReader(carr);
              var os = new CharArrayWriter()) {
@@ -373,7 +373,7 @@ class IOStreamsCopyTest {
     }
 
     @Test
-    void copyLargeCharSkip() throws IOException {
+    void copyLargeCharSkip() throws Exception {
         // Create streams
         try (var is = new CharArrayReader(carr);
              var os = new CharArrayWriter()) {
@@ -403,7 +403,7 @@ class IOStreamsCopyTest {
     }
 
     @Test
-    void copyLargeExtraLength() throws IOException {
+    void copyLargeExtraLength() throws Exception {
         // Create streams
         try (var is = new ByteArrayInputStream(iarr);
              var os = new ByteArrayOutputStream()) {
@@ -422,7 +422,7 @@ class IOStreamsCopyTest {
     }
 
     @Test
-    void copyLargeFullLength() throws IOException {
+    void copyLargeFullLength() throws Exception {
         // Create streams
         try (var is = new ByteArrayInputStream(iarr);
              var os = new ByteArrayOutputStream()) {
@@ -440,7 +440,7 @@ class IOStreamsCopyTest {
     }
 
     @Test
-    void copyLargeNoSkip() throws IOException {
+    void copyLargeNoSkip() throws Exception {
         // Create streams
         try (var is = new ByteArrayInputStream(iarr);
              var os = new ByteArrayOutputStream()) {
@@ -458,7 +458,7 @@ class IOStreamsCopyTest {
     }
 
     @Test
-    void copyLargeSkip() throws IOException {
+    void copyLargeSkip() throws Exception {
         // Create streams
         try (var is = new ByteArrayInputStream(iarr);
              var os = new ByteArrayOutputStream()) {

--- a/src/test/java/de/cuioss/tools/io/IOStreamsTest.java
+++ b/src/test/java/de/cuioss/tools/io/IOStreamsTest.java
@@ -68,7 +68,7 @@ class IOStreamsTest {
     }
 
     @Test
-    void shouldProvideInputStream() throws IOException {
+    void shouldProvideInputStream() throws Exception {
         assertTrue(contentEquals(new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)), toInputStream(null)));
         assertFalse(
                 contentEquals(new ByteArrayInputStream("ABCD".getBytes(StandardCharsets.UTF_8)), toInputStream("ABC")));

--- a/src/test/java/de/cuioss/tools/io/MorePathsTest.java
+++ b/src/test/java/de/cuioss/tools/io/MorePathsTest.java
@@ -114,7 +114,7 @@ class MorePathsTest {
     }
 
     @Test
-    void shouldCheckExecutablePath() throws IOException {
+    void shouldCheckExecutablePath() throws Exception {
         assertFalse(checkExecutablePath(BASE_PATH, true));
         assertFalse(checkExecutablePath(BASE_PATH, false));
 
@@ -143,7 +143,7 @@ class MorePathsTest {
     }
 
     @Test
-    void shouldBackupExistingFile() throws IOException {
+    void shouldBackupExistingFile() throws Exception {
         var existing = copyPomFileToPlayground();
 
         assertFalse(Files.exists(playGroundBackup));
@@ -160,7 +160,7 @@ class MorePathsTest {
     }
 
     @Test
-    void shouldCreateTempFile() throws IOException {
+    void shouldCreateTempFile() throws Exception {
         var existing = copyPomFileToPlayground();
 
         assertFalse(Files.exists(playGroundBackup));
@@ -177,7 +177,7 @@ class MorePathsTest {
     }
 
     @Test
-    void shouldBackupFileWithoutParent() throws IOException {
+    void shouldBackupFileWithoutParent() throws Exception {
         // Single-segment relative path -> Path#getParent() is null
         var relativePath = Path.of(
                 "morePathsBackupTest" + FILE_SUFFIX_DATEFORMAT.format(new Date()) + ".txt");
@@ -207,7 +207,7 @@ class MorePathsTest {
     }
 
     @Test
-    void shouldDetermineFilename() throws IOException {
+    void shouldDetermineFilename() throws Exception {
         final List<Path> children = Files.list(playGroundBase).toList();
         assertTrue(children.isEmpty());
         var filename = "filename";
@@ -234,7 +234,7 @@ class MorePathsTest {
     }
 
     @Test
-    void shouldSaveAndBackup() throws IOException {
+    void shouldSaveAndBackup() throws Exception {
         var existingFile = copyPomFileToPlayground();
 
         saveAndBackup(existingFile, filePath -> assertNotEquals(existingFile.toAbsolutePath().toString(),
@@ -269,7 +269,7 @@ class MorePathsTest {
     }
 
     @Test
-    void deleteQuietlyDir() throws IOException {
+    void deleteQuietlyDir() throws Exception {
         var existingFile = copyPomFileToPlayground();
 
         var testDirectory = playGroundBackup.resolve("directory");
@@ -283,7 +283,7 @@ class MorePathsTest {
     }
 
     @Test
-    void deleteQuietlyFile() throws IOException {
+    void deleteQuietlyFile() throws Exception {
         var existingFile = copyPomFileToPlayground();
 
         assertTrue(existingFile.toFile().exists());

--- a/src/test/java/de/cuioss/tools/io/PathTraversalSecurityTest.java
+++ b/src/test/java/de/cuioss/tools/io/PathTraversalSecurityTest.java
@@ -53,7 +53,7 @@ class PathTraversalSecurityTest {
     }
 
     @Test
-    void fileLoaderUtilityCopyFileToTempWithPathTraversal() throws IOException {
+    void fileLoaderUtilityCopyFileToTempWithPathTraversal() throws Exception {
         // Test 1: Attempt to access file with "../" in path
         Path traversalPath = subDir.resolve("../../../sensitive.txt");
 
@@ -87,7 +87,7 @@ class PathTraversalSecurityTest {
     }
 
     @Test
-    void fileLoaderUtilityCopyFileToTempWithSymbolicLink() throws IOException {
+    void fileLoaderUtilityCopyFileToTempWithSymbolicLink() throws Exception {
         // Create a symbolic link that points outside the safe directory
         Path symLink = subDir.resolve("symlink.txt");
 
@@ -113,7 +113,7 @@ class PathTraversalSecurityTest {
     }
 
     @Test
-    void morePathsCopyToTempLocationWithPathTraversal() throws IOException {
+    void morePathsCopyToTempLocationWithPathTraversal() throws Exception {
         // Test 1: Attempt to copy file with "../" in path
         Path traversalPath = subDir.resolve("../../sensitive.txt");
 
@@ -138,7 +138,7 @@ class PathTraversalSecurityTest {
     }
 
     @Test
-    void morePathsCopyToTempLocationWithAbsolutePath() throws IOException {
+    void morePathsCopyToTempLocationWithAbsolutePath() throws Exception {
         // Test with absolute path to sensitive file
         if (Files.exists(sensitiveFile)) {
             // This should be allowed but the result should be in temp directory
@@ -245,7 +245,7 @@ class PathTraversalSecurityTest {
     }
 
     @Test
-    void realPathResolution() throws IOException {
+    void realPathResolution() throws Exception {
         // Test toRealPath() for detecting actual file locations
         Path pathWithDots = subDir.resolve("../safe.txt");
 
@@ -260,7 +260,7 @@ class PathTraversalSecurityTest {
     }
 
     @Test
-    void fileLoaderUtilityRejectsMaliciousFilenames() throws IOException {
+    void fileLoaderUtilityRejectsMaliciousFilenames() throws Exception {
         // Create a test file with a simple name
         Path normalFile = tempDir.resolve("normal.txt");
         Files.writeString(normalFile, "Normal content");

--- a/src/test/java/de/cuioss/tools/io/UrlLoaderTest.java
+++ b/src/test/java/de/cuioss/tools/io/UrlLoaderTest.java
@@ -50,7 +50,7 @@ class UrlLoaderTest {
     }
 
     @Test
-    void shouldHandleValidResource() throws IOException {
+    void shouldHandleValidResource() throws Exception {
         var url = UrlLoaderTest.class.getResource("/someTestFile.txt");
         assertNotNull(url, "Test resource not found");
 
@@ -63,7 +63,7 @@ class UrlLoaderTest {
     }
 
     @Test
-    void shouldProvideInputStreamAfterIsReadable() throws IOException {
+    void shouldProvideInputStreamAfterIsReadable() throws Exception {
         var url = UrlLoaderTest.class.getResource("/someTestFile.txt");
         assertNotNull(url, "Test resource not found");
         var loader = new UrlLoader(url);
@@ -76,7 +76,7 @@ class UrlLoaderTest {
     }
 
     @Test
-    void shouldProvideInputStreamMultipleTimes() throws IOException {
+    void shouldProvideInputStreamMultipleTimes() throws Exception {
         var url = UrlLoaderTest.class.getResource("/someTestFile.txt");
         assertNotNull(url, "Test resource not found");
         var loader = new UrlLoader(url);

--- a/src/test/java/de/cuioss/tools/logging/CuiLoggerFactoryTest.java
+++ b/src/test/java/de/cuioss/tools/logging/CuiLoggerFactoryTest.java
@@ -93,7 +93,7 @@ class CuiLoggerFactoryTest {
     }
 
     @Test
-    void shouldAutoDetectCallerFromBottomOfStackFrame() throws InterruptedException {
+    void shouldAutoDetectCallerFromBottomOfStackFrame() throws Exception {
         // A Thread subclass overriding run() and calling getLogger() directly produces the
         // minimal possible stack of four frames: Thread#getStackTrace, findCallerInternal,
         // getLogger and run() itself. Caller detection must still succeed for such a stack.
@@ -112,7 +112,7 @@ class CuiLoggerFactoryTest {
     }
 
     @Test
-    void shouldHandleMultithreadedInitialization() throws InterruptedException {
+    void shouldHandleMultithreadedInitialization() throws Exception {
         // Test concurrent initialization to ensure thread safety
         final int threadCount = 10;
         Thread[] threads = new Thread[threadCount];

--- a/src/test/java/de/cuioss/tools/logging/LogRecordModelTest.java
+++ b/src/test/java/de/cuioss/tools/logging/LogRecordModelTest.java
@@ -17,9 +17,7 @@ package de.cuioss.tools.logging;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test class for {@link LogRecordModel} ensuring proper log message formatting

--- a/src/test/java/de/cuioss/tools/net/ssl/KeyStoreProviderTest.java
+++ b/src/test/java/de/cuioss/tools/net/ssl/KeyStoreProviderTest.java
@@ -31,7 +31,6 @@ import java.io.File;
 import java.math.BigInteger;
 import java.security.KeyPairGenerator;
 import java.security.KeyStore;
-import java.security.KeyStoreException;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -361,7 +360,7 @@ class KeyStoreProviderTest {
 
     // File Based Keystore tests
     @Test
-    void shouldHandleEmptyKeyStore() throws KeyStoreException {
+    void shouldHandleEmptyKeyStore() throws Exception {
         var provider = KeyStoreProvider.builder().location(KeystoreInformation.EMPTY_KEY_STORE.toFile())
                 .storePassword(KeystoreInformation.PASSWORD).keyStoreType(KeyStoreType.KEY_STORE).build();
         var keystore = provider.resolveKeyStore();
@@ -377,7 +376,7 @@ class KeyStoreProviderTest {
     }
 
     @Test
-    void shouldHandleUnprotectedEmptyKeyStore() throws KeyStoreException {
+    void shouldHandleUnprotectedEmptyKeyStore() throws Exception {
         var provider = KeyStoreProvider.builder().location(KeystoreInformation.EMPTY_KEY_STORE_NO_PASSWORD.toFile())
                 .keyStoreType(KeyStoreType.KEY_STORE).build();
         var keystore = provider.resolveKeyStore();

--- a/src/test/java/de/cuioss/tools/property/PropertyReadWriteTest.java
+++ b/src/test/java/de/cuioss/tools/property/PropertyReadWriteTest.java
@@ -38,7 +38,7 @@ class PropertyReadWriteTest {
     }
 
     @Test
-    void shouldResolvePropertyDescriptor() throws IntrospectionException {
+    void shouldResolvePropertyDescriptor() throws Exception {
         assertEquals(READ_WRITE,
                 resolveWithPropertyDescriptor(BeanWithReadWriteProperties.class, ATTRIBUTE_READ_WRITE));
         assertEquals(READ_WRITE,

--- a/src/test/java/de/cuioss/tools/reflect/MoreReflectionTest.java
+++ b/src/test/java/de/cuioss/tools/reflect/MoreReflectionTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.InvocationHandler;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 import static de.cuioss.tools.collect.CollectionLiterals.mutableList;
@@ -65,7 +64,7 @@ class MoreReflectionTest {
 
     @Test
     void shouldFilterAccessGetterMethods() {
-        assertEquals(3, MoreReflection.retrieveAccessMethods(MethodNameClass.class, Collections.emptyList()).size());
+        assertEquals(3, MoreReflection.retrieveAccessMethods(MethodNameClass.class, List.of()).size());
         assertEquals(2, MoreReflection.retrieveAccessMethods(MethodNameClass.class, mutableList("name")).size());
     }
 


### PR DESCRIPTION
## Summary

Cluster I of the project-analysis fix series (findings catalog: `doc/analysis-findings.md`, ID REW-1) — the output of the pre-commit profile's OpenRewrite run, which previously left the working tree dirty on every `./mvnw -Ppre-commit clean verify` invocation:

- `Collections.emptyList()/emptyMap()/emptySet()` → `List.of()/Map.of()/Set.of()` across main sources
- if-else-if chain → `switch` in `Joiner`
- JUnit 5 test cleanups (`SimplifyTestThrows`) across test sources
- `jakarta.annotation-api` scope back to `provided`: the pre-commit tooling itself enforces this scope, superseding the manual `test` scope from the docs/build PR (#196) — keeping `test` would leave the tree perpetually dirty for anyone running pre-commit

No hand-written changes; everything in this PR is generated by the project's own `-Ppre-commit` profile on top of current main.

## Test plan

- `./mvnw clean install` — BUILD SUCCESS, full suite green
- `./mvnw -Ppre-commit clean verify -DskipTests` — leaves a clean working tree afterwards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKzn4Upj33uRFvWQep3UzE

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKzn4Upj33uRFvWQep3UzE)_