### PR TITLE
ci: add centralized CodeQL workflow and README badge

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,27 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '27 4 * * 3'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    # Centralized in cuioss-organization, matching every other security/CI workflow in this repo.
+    # The reusable workflow fixes the query suite to +security-and-quality org-wide;
+    # build-mode: none analyses the sources directly (no Maven build needed for this
+    # zero-dependency library).
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-codeql.yml@181cc6a24d4c2b6fe7378b9ac94ac3df4665de7b # v0.7.0
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    with:
+      languages: '["java"]'
+      build-mode: none

--- a/README.adoc
+++ b/README.adoc
@@ -3,6 +3,7 @@
 == Status
 
 image:https://github.com/cuioss/cui-java-tools/actions/workflows/maven.yml/badge.svg[Java CI with Maven,link=https://github.com/cuioss/cui-java-tools/actions/workflows/maven.yml]
+image:https://github.com/cuioss/cui-java-tools/actions/workflows/codeql.yml/badge.svg[CodeQL,link=https://github.com/cuioss/cui-java-tools/actions/workflows/codeql.yml]
 image:http://img.shields.io/:license-apache-blue.svg[License,link=http://www.apache.org/licenses/LICENSE-2.0.html]
 image:https://img.shields.io/maven-central/v/de.cuioss/cui-java-tools.svg?label=Maven%20Central["Maven Central", link="https://central.sonatype.com/artifact/de.cuioss/cui-java-tools"]
 


### PR DESCRIPTION
## Summary

Instruments CodeQL scanning and surfaces its status, mirroring cui-http PR #82 (F-16).

- **`.github/workflows/codeql.yml`** — delegates to the `cuioss-organization` reusable CodeQL workflow (`reusable-codeql.yml @ v0.7.0`, the same pinned ref this repo already uses for `maven.yml`/`release.yml`). Triggers on push/PR to `main` and a weekly schedule. `languages: java`, `build-mode: none` (source analysis — no Maven build needed for this zero-dependency library). The reusable workflow fixes the query suite to `+security-and-quality` org-wide.
- **README badge** — adds a CodeQL status badge to the Status section, in the existing badge style, next to the Maven CI badge.

## Verification
- Confirmed `cuioss/cuioss-organization/.github/workflows/reusable-codeql.yml` exists at the pinned `v0.7.0` SHA.
- YAML/AsciiDoc-only change; no sources touched.