### PR TITLE
fix(codeql): resolve and triage CodeQL findings

### DIFF
--- a/src/main/java/de/cuioss/tools/io/FileLoaderUtility.java
+++ b/src/main/java/de/cuioss/tools/io/FileLoaderUtility.java
@@ -18,7 +18,6 @@ package de.cuioss.tools.io;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
-import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
@@ -99,7 +98,7 @@ public final class FileLoaderUtility {
         final Path target = PathTraversalSecurity.createSecureTempFile(namePart, null != suffix ? "." + suffix : null);
 
         try (final var inputStream = source.inputStream()) {
-            Files.copy(new BufferedInputStream(inputStream), target, StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(inputStream, target, StandardCopyOption.REPLACE_EXISTING);
         }
         if (markDeleteOnExit) {
             target.toFile().deleteOnExit();

--- a/src/test/java/de/cuioss/tools/collect/CollectionLiteralsTest.java
+++ b/src/test/java/de/cuioss/tools/collect/CollectionLiteralsTest.java
@@ -284,7 +284,7 @@ class CollectionLiteralsTest {
         @DisplayName("Should handle stream to immutable map conversion")
         void shouldHandleStreamToImmutableMap() {
             final Map<String, String> result = immutableMap(
-                    immutableMap("1", "1-1", "2", "").entrySet().stream().filter(entry -> !"".equals(entry.getValue())));
+                    immutableMap("1", "1-1", "2", "").entrySet().stream().filter(entry -> !entry.getValue().isEmpty()));
             assertEquals(1, result.size());
             assertTrue(result.containsKey("1"));
         }

--- a/src/test/java/de/cuioss/tools/io/FileSystemLoaderTest.java
+++ b/src/test/java/de/cuioss/tools/io/FileSystemLoaderTest.java
@@ -16,6 +16,7 @@
 package de.cuioss.tools.io;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -135,10 +136,9 @@ class FileSystemLoaderTest {
     }
 
     @Test
-    void shouldHandleOutputStreamForWritableFile() throws Exception {
-        // Create a temporary file for testing
-        File tempFile = Files.createTempFile("test", ".txt").toFile();
-        tempFile.deleteOnExit();
+    void shouldHandleOutputStreamForWritableFile(@TempDir Path tempDir) throws Exception {
+        // Create a temporary file inside the JUnit-managed temp directory (auto-cleaned)
+        File tempFile = Files.createFile(tempDir.resolve("test.txt")).toFile();
 
         var loader = new FileSystemLoader(tempFile.getAbsolutePath());
         assertTrue(loader.isWritable());

--- a/src/test/java/de/cuioss/tools/io/FileSystemLoaderTest.java
+++ b/src/test/java/de/cuioss/tools/io/FileSystemLoaderTest.java
@@ -18,6 +18,7 @@ package de.cuioss.tools.io;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -136,7 +137,7 @@ class FileSystemLoaderTest {
     @Test
     void shouldHandleOutputStreamForWritableFile() throws Exception {
         // Create a temporary file for testing
-        File tempFile = File.createTempFile("test", ".txt");
+        File tempFile = Files.createTempFile("test", ".txt").toFile();
         tempFile.deleteOnExit();
 
         var loader = new FileSystemLoader(tempFile.getAbsolutePath());

--- a/src/test/java/de/cuioss/tools/support/TestDataGenerator.java
+++ b/src/test/java/de/cuioss/tools/support/TestDataGenerator.java
@@ -54,7 +54,7 @@ public class TestDataGenerator implements TypedGenerator<byte[]> {
     }
 
     private static void generateTestData(final OutputStream out, final long size) throws IOException {
-        for (var i = 0; i < size; i++) {
+        for (long i = 0; i < size; i++) {
             // nice varied byte pattern compatible with Readers and Writers
             out.write((byte) (i % 127 + 1));
         }


### PR DESCRIPTION
## Summary

Addresses the open CodeQL findings for the repository. Structural Scorecard alerts (Branch-Protection, SAST, Fuzzing, etc.) are out of scope and left untouched.

### Fixed in code (4)
| Alert | Rule | File | Fix |
|------|------|------|-----|
| 39 | `java/input-resource-leak` | `FileLoaderUtility` | Copy the input stream directly instead of wrapping it in an unclosed `BufferedInputStream` |
| 14 | `java/comparison-with-wider-type` | `TestDataGenerator` | Use a `long` loop counter to match the `long` bound |
| 37 | `java/inefficient-empty-string-test` | `CollectionLiteralsTest` | Use `String.isEmpty()` instead of comparing to `""` |
| 15 | `java/local-temp-file...-information-disclosure` | `FileSystemLoaderTest` | Create the temp file via `Files.createTempFile` (secure default permissions) |

### Dismissed via API (53)
- **False positive — Lombok-generated methods (17):** `java/missing-override-annotation` and `java/unknown-javadoc-parameter` are reported against `@Getter`/`@ToString`/`@EqualsAndHashCode`-generated methods; `@Override` cannot be added to generated code and the class-level `@param <T>` javadoc is correct.
- **Used in tests (26):** deliberate test doubles/fixtures preserving contract signatures (`Proxy*`/`Null*` streams, bean fixtures), tests of deprecated API, and null-argument precondition tests (`java/unused-parameter`, `java/deprecated-call`, `java/uncaught-number-format-exception`, `java/dereferenced-expr-may-be-null`).
- **Won't fix (10):** `java/confusing-method-signature` on intentional public-API overloads that cannot be renamed without breaking the Maven Central API, and `java/missing-clone-method` on `PartialArrayList` which inherits `Cloneable` transitively from `ArrayList` and is not designed for cloning.

## Verification
`./mvnw -Ppre-commit clean verify` — BUILD SUCCESS, 887 tests pass, clean tree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved temporary file handling during file loading for more reliable copy behavior.

* **Tests**
  * Updated file-system tests to use JUnit-managed temporary directories for cleaner, more stable test setup.
  * Adjusted collection tests to better reflect empty-value filtering behavior.
  * Minor test utility cleanup for clearer loop typing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->