### PR TITLE
chore(release): prepare release 2.7.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,8 +1,8 @@
 name: cui-java-tools
 
 release:
-  current-version: 2.6.2
-  next-version: 2.6-SNAPSHOT
+  current-version: 2.7.0
+  next-version: 2.7-SNAPSHOT
   create-github-release: true
 
 maven-build:


### PR DESCRIPTION
Start the 2.7 minor line: bump `current-version` to `2.7.0` and `next-version` to `2.7-SNAPSHOT`. Merging this PR triggers the automated Release workflow.