### PR TITLE
fix: drop unsupported semver cooldown keys from github-actions entry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,8 +19,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+    # Only `default-days`: the `semver-*-days` keys are rejected for the
+    # github-actions ecosystem, and one rejected key invalidates the whole file,
+    # which disables version updates for the entire repo.
     cooldown:
       default-days: 3
-      semver-major-days: 7
-      semver-minor-days: 3
-      semver-patch-days: 1


### PR DESCRIPTION
## Dependabot version updates have been disabled in this repo since 2026-02-19

`.github/dependabot.yml` is invalid. Dependabot's check-run on `7fa52b37` — the last commit to touch the file — reports `failure`:

```
The property '#/updates/1/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
(same for semver-minor-days and semver-patch-days)
```

A single rejected property invalidates the **entire file**, so version updates have been off for **every** ecosystem here — `maven` included, not just the `github-actions` entry.

It stayed invisible for two reasons: Dependabot reports config errors in a *check-run*, not an Actions run (so `gh run list` and a green build never show it), and that check only re-runs when `dependabot.yml` itself changes — so every commit since has been silent about it.

## The fix

Removed the three `semver-*-days` keys from the `github-actions` entry, keeping `default-days: 3`. The `maven` entry supports them and keeps its tiering. A short comment records why the keys must not come back.

## Verification

- Parses locally; `github-actions` → `{default-days: 3}`, `maven` → tiered block unchanged.
- The authoritative confirmation is the `.github/dependabot.yml` check-run on the merge commit, which is where Dependabot re-validates. Will verify there after merge.

## Context

Found by an org-wide sweep of all 24 cuioss repos carrying a `dependabot.yml`; 5 were broken the same way. Root cause was the org-level `/update-github-actions` command instructing the tiered block on every ecosystem entry — fixed in cuioss/cuioss-organization#233, with the "repair an existing wrong block" case in cuioss/cuioss-organization#234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CucanbUKECmSi3Bn6TFxxw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings to use the supported cooldown configuration.
  * Removed unsupported version-specific cooldown options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->